### PR TITLE
Remove Submit Message

### DIFF
--- a/src/main/java/edu/rpi/legup/ui/LegupUI.java
+++ b/src/main/java/edu/rpi/legup/ui/LegupUI.java
@@ -493,11 +493,13 @@ public class LegupUI extends JFrame implements WindowListener, IHistoryListener 
         Puzzle puzzle = facade.getPuzzleModule();
 
         if (puzzle.isPuzzleComplete()) {
-            int confirm = JOptionPane.showConfirmDialog(null, "Congratulations! Your proof is correct. Would you like to submit?", "Proof Submission", JOptionPane.YES_NO_OPTION);
+            // This is for submission which is not integrated yet
+            /*int confirm = JOptionPane.showConfirmDialog(null, "Congratulations! Your proof is correct. Would you like to submit?", "Proof Submission", JOptionPane.YES_NO_OPTION);
             if (confirm == JOptionPane.YES_OPTION) {
                 Submission submission = new Submission(board);
                 submission.submit();
-            }
+            }*/
+            JOptionPane.showMessageDialog(null, "Congratulations! Your proof is correct.");
             showStatus("Your proof is correct.", false);
         } else {
             String message = "\nThe game board is not solved.";


### PR DESCRIPTION
**Current Behavior**
When you check that you have completed a puzzle successfully you are asked if you would like to submit.
![image](https://user-images.githubusercontent.com/55092742/135161443-e809a863-d1bb-4631-b8b1-7f27870f2366.png)


**New Behavior**
You are instead given only a message saying your proof is correct.
![image](https://user-images.githubusercontent.com/55092742/135161289-bd7c392c-1004-4982-a470-d04818e03ca9.png)
Closes #36