### PR TITLE
Implemented UID System for Rules

### DIFF
--- a/src/main/java/edu/rpi/legup/model/Puzzle.java
+++ b/src/main/java/edu/rpi/legup/model/Puzzle.java
@@ -386,6 +386,35 @@ public abstract class Puzzle implements IBoardSubject, ITreeSubject {
     }
 
     /**
+     * Gets the rule using the specified name
+     *
+     * @param id name of the rule
+     * @return Rule
+     */
+    public Rule getRuleByID(String id) {
+        for (Rule rule : basicRules) {
+            if (rule.getRuleID().equals(id)) {
+                return rule;
+            }
+        }
+        for (Rule rule : contradictionRules) {
+            if (rule.getRuleID().equals(id)) {
+                return rule;
+            }
+        }
+        for (Rule rule : caseRules) {
+            if (rule.getRuleID().equals(id)) {
+                return rule;
+            }
+        }
+        Rule mergeRule = new MergeRule();
+        if (mergeRule.getRuleID().equals(id)) {
+            return mergeRule;
+        }
+        return null;
+    }
+
+    /**
      * Gets the current board
      *
      * @return current board

--- a/src/main/java/edu/rpi/legup/model/PuzzleExporter.java
+++ b/src/main/java/edu/rpi/legup/model/PuzzleExporter.java
@@ -44,7 +44,7 @@ public abstract class PuzzleExporter {
             Document newDocument = docBuilder.newDocument();
 
             org.w3c.dom.Element legupElement = newDocument.createElement("Legup");
-            legupElement.setAttribute("version", "2.0.0");
+            legupElement.setAttribute("version", "3.0.0");
             newDocument.appendChild(legupElement);
 
             org.w3c.dom.Element puzzleElement = newDocument.createElement("puzzle");
@@ -112,6 +112,7 @@ public abstract class PuzzleExporter {
 
                     if (transition.isJustified()) {
                         transElement.setAttribute("rule", transition.getRule().getRuleName());
+                        transElement.setAttribute("rule_id", transition.getRule().getRuleID());
                     }
 
                     for (PuzzleElement data : transition.getBoard().getModifiedData()) {

--- a/src/main/java/edu/rpi/legup/model/PuzzleImporter.java
+++ b/src/main/java/edu/rpi/legup/model/PuzzleImporter.java
@@ -154,10 +154,10 @@ public abstract class PuzzleImporter {
             String nodeId = treeNodeElement.getAttribute("id");
             String isRoot = treeNodeElement.getAttribute("root");
             if (nodeId.isEmpty()) {
-                throw new InvalidFileFormatException("Proof Tree construction error: cannot find node id");
+                throw new InvalidFileFormatException("Proof Tree construction error: cannot find node ID");
             }
             if (treeNodes.containsKey(nodeId)) {
-                throw new InvalidFileFormatException("Proof Tree construction error: duplicate tree node id found");
+                throw new InvalidFileFormatException("Proof Tree construction error: duplicate tree node ID found");
             }
             TreeNode treeNode = new TreeNode(puzzle.getCurrentBoard().copy());
             if (isRoot.equalsIgnoreCase("true")) {
@@ -187,13 +187,14 @@ public abstract class PuzzleImporter {
                         treeNode.addChild(transition);
                         continue;
                     } else {
-                        throw new InvalidFileFormatException("Proof Tree construction error: duplicate transition id found");
+                        throw new InvalidFileFormatException("Proof Tree construction error: duplicate transition ID found");
                     }
 
                 }
 
                 String childId = trans.getAttribute("child");
                 String ruleName = trans.getAttribute("rule");
+                String ruleId = trans.getAttribute("rule_id");
 
                 TreeNode child = treeNodes.get(childId);
 
@@ -201,9 +202,9 @@ public abstract class PuzzleImporter {
 
                 Rule rule;
                 if (!ruleName.isEmpty()) {
-                    rule = puzzle.getRuleByName(ruleName);
+                    rule = puzzle.getRuleByID(ruleId);
                     if (rule == null) {
-                        throw new InvalidFileFormatException("Proof Tree construction error: could not find rule by name");
+                        throw new InvalidFileFormatException("Proof Tree construction error: could not find rule by ID");
                     }
                     transition.setRule(rule);
                 }

--- a/src/main/java/edu/rpi/legup/model/rules/BasicRule.java
+++ b/src/main/java/edu/rpi/legup/model/rules/BasicRule.java
@@ -11,12 +11,13 @@ public abstract class BasicRule extends Rule {
     /**
      * BasicRule Constructor creates a new basic rule.
      *
+     * @param ruleID      ID of the rule
      * @param ruleName    name of the rule
      * @param description description of the rule
      * @param imageName   file name of the image
      */
-    public BasicRule(String ruleName, String description, String imageName) {
-        super(ruleName, description, imageName);
+    public BasicRule(String ruleID, String ruleName, String description, String imageName) {
+        super(ruleID, ruleName, description, imageName);
         this.ruleType = BASIC;
     }
 

--- a/src/main/java/edu/rpi/legup/model/rules/CaseRule.java
+++ b/src/main/java/edu/rpi/legup/model/rules/CaseRule.java
@@ -20,12 +20,13 @@ public abstract class CaseRule extends Rule {
     /**
      * CaseRule Constructor creates a new case rule.
      *
+     * @param ruleID      ID of the rule
      * @param ruleName    name of the rule
      * @param description description of the rule
      * @param imageName   file name of the image
      */
-    public CaseRule(String ruleName, String description, String imageName) {
-        super(ruleName, description, imageName);
+    public CaseRule(String ruleID, String ruleName, String description, String imageName) {
+        super(ruleID, ruleName, description, imageName);
         this.ruleType = CASE;
         this.INVALID_USE_MESSAGE = "Invalid use of the case rule " + this.ruleName;
     }

--- a/src/main/java/edu/rpi/legup/model/rules/ContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/model/rules/ContradictionRule.java
@@ -13,12 +13,13 @@ public abstract class ContradictionRule extends Rule {
     /**
      * ContradictionRule Constructor creates a new contradiction rule
      *
+     * @param ruleID      ID of the rule
      * @param ruleName    name of the rule
      * @param description description of the rule
      * @param imageName   file name of the image
      */
-    public ContradictionRule(String ruleName, String description, String imageName) {
-        super(ruleName, description, imageName);
+    public ContradictionRule(String ruleID, String ruleName, String description, String imageName) {
+        super(ruleID, ruleName, description, imageName);
         ruleType = CONTRADICTION;
     }
 

--- a/src/main/java/edu/rpi/legup/model/rules/MergeRule.java
+++ b/src/main/java/edu/rpi/legup/model/rules/MergeRule.java
@@ -19,7 +19,7 @@ public class MergeRule extends Rule {
      * MergeRule Constructor merges to board states together
      */
     public MergeRule() {
-        super("Merge Rule",
+        super("MERGE","Merge Rule",
                 "Merge any number of nodes into one",
                 "edu/rpi/legup/images/Legup/MergeRule.png");
         this.ruleType = MERGE;

--- a/src/main/java/edu/rpi/legup/model/rules/Rule.java
+++ b/src/main/java/edu/rpi/legup/model/rules/Rule.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 
 @RegisterRule
 public abstract class Rule {
+    protected String ruleID;
     protected String ruleName;
     protected String description;
     protected String imageName;
@@ -24,14 +25,16 @@ public abstract class Rule {
     /**
      * Rule Constructor creates a new rule
      *
+     * @param ruleID      ID of the rule
      * @param ruleName    name of the rule
      * @param description description of the rule
      * @param imageName   file name of the image
      */
-    public Rule(String ruleName, String description, String imageName) {
-        this.imageName = imageName;
+    public Rule(String ruleID, String ruleName, String description, String imageName) {
+        this.ruleID = ruleID;
         this.ruleName = ruleName;
         this.description = description;
+        this.imageName = imageName;
         this.INVALID_USE_MESSAGE = "Invalid use of the rule " + this.ruleName;
         loadImage();
     }
@@ -106,6 +109,15 @@ public abstract class Rule {
      */
     public String getRuleName() {
         return ruleName;
+    }
+
+    /**
+     * Gets the name of the rule
+     *
+     * @return name of the rule
+     */
+    public String getRuleID() {
+        return ruleID;
     }
 
     /**

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/AdjacentShipsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/AdjacentShipsContradictionRule.java
@@ -7,7 +7,8 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class AdjacentShipsContradictionRule extends ContradictionRule {
 
     public AdjacentShipsContradictionRule() {
-        super("Adjacent Ships",
+        super("BTSP-CONT-0001",
+                "Adjacent Ships",
                 "",
                 "edu/rpi/legup/images/battleship/contradictions/AdjacentShips.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/ContinueShipBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/ContinueShipBasicRule.java
@@ -9,7 +9,8 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class ContinueShipBasicRule extends BasicRule {
 
     public ContinueShipBasicRule() {
-        super("Continue Ship",
+        super("BTSP-BASC-0001",
+                "Continue Ship",
                 "",
                 "edu/rpi/legup/images/battleship/rules/ContinueShip.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/FinishWithWaterBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/FinishWithWaterBasicRule.java
@@ -9,7 +9,8 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class FinishWithWaterBasicRule extends BasicRule {
 
     public FinishWithWaterBasicRule() {
-        super("Finish with Water",
+        super("BTSP-BASC-0003",
+                "Finish with Water",
                 "",
                 "edu/rpi/legup/images/battleship/rules/finishWater.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/FinishedWithShipsBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/FinishedWithShipsBasicRule.java
@@ -9,7 +9,8 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class FinishedWithShipsBasicRule extends BasicRule {
 
     public FinishedWithShipsBasicRule() {
-        super("Finished with Ships",
+        super("BTSP-BASC-0002",
+                "Finished with Ships",
                 "",
                 "edu/rpi/legup/images/battleship/rules/finishShip.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/IncompleteShipContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/IncompleteShipContradictionRule.java
@@ -7,7 +7,8 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class IncompleteShipContradictionRule extends ContradictionRule {
 
     public IncompleteShipContradictionRule() {
-        super("Incomplete Ship",
+        super("BTSP-CONT-0002",
+                "Incomplete Ship",
                 "",
                 "edu/rpi/legup/images/battleship/contradictions/IncompleteShip.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/SegmentTypeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/SegmentTypeBasicRule.java
@@ -9,7 +9,8 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class SegmentTypeBasicRule extends BasicRule {
 
     public SegmentTypeBasicRule() {
-        super("Segment Type",
+        super("BTSP-BASC-0004",
+                "Segment Type",
                 "",
                 "edu/rpi/legup/images/battleship/rules/SegmentChoice.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/SegmentTypeCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/SegmentTypeCaseRule.java
@@ -10,7 +10,8 @@ import java.util.List;
 
 public class SegmentTypeCaseRule extends CaseRule {
     public SegmentTypeCaseRule() {
-        super("Segment Type",
+        super("BTSP-CASE-0001",
+                "Segment Type",
                 "",
                 "edu/rpi/legup/images/battleship/cases/SegmentType.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/ShipLocationCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/ShipLocationCaseRule.java
@@ -11,7 +11,8 @@ import java.util.List;
 public class ShipLocationCaseRule extends CaseRule {
 
     public ShipLocationCaseRule() {
-        super("Ship Location",
+        super("BTSP-CASE-0002",
+                "Ship Location",
                 "",
                 "edu/rpi/legup/images/battleship/cases/ShipLocations.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/ShipOrWaterCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/ShipOrWaterCaseRule.java
@@ -11,7 +11,8 @@ import java.util.List;
 public class ShipOrWaterCaseRule extends CaseRule {
 
     public ShipOrWaterCaseRule() {
-        super("Ship or Water",
+        super("BTSP-CASE-0003",
+                "Ship or Water",
                 "",
                 "edu/rpi/legup/images/battleship/cases/ShipOrWater.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/SurroundShipBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/SurroundShipBasicRule.java
@@ -9,7 +9,8 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class SurroundShipBasicRule extends BasicRule {
 
     public SurroundShipBasicRule() {
-        super("Surround Ship",
+        super("BTSP-BASC-0005",
+                "Surround Ship",
                 "",
                 "edu/rpi/legup/images/battleship/rules/SurroundShip.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooFewInFleetContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooFewInFleetContradictionRule.java
@@ -7,7 +7,8 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class TooFewInFleetContradictionRule extends ContradictionRule {
 
     public TooFewInFleetContradictionRule() {
-        super("Too Few in Fleet",
+        super("BTSP-CONT-0003",
+                "Too Few in Fleet",
                 "",
                 "edu/rpi/legup/images/battleship/contradictions/too_few_in_fleet.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooFewRowColContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooFewRowColContradictionRule.java
@@ -7,7 +7,8 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class TooFewRowColContradictionRule extends ContradictionRule {
 
     public TooFewRowColContradictionRule() {
-        super("Too few in row/col",
+        super("BTSP-CONT-0004",
+                "Too few in row/col",
                 "",
                 "edu/rpi/legup/images/battleship/contradictions/too_few_segments.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooManyInFleetContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooManyInFleetContradictionRule.java
@@ -7,7 +7,8 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class TooManyInFleetContradictionRule extends ContradictionRule {
 
     public TooManyInFleetContradictionRule() {
-        super("Too Many in Fleet",
+        super("BTSP-CONT-0005",
+                "Too Many in Fleet",
                 "",
                 "edu/rpi/legup/images/battleship/contradictions/too_many_in_fleet.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooManyRowColContradiction.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/TooManyRowColContradiction.java
@@ -7,7 +7,8 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class TooManyRowColContradiction extends ContradictionRule {
 
     public TooManyRowColContradiction() {
-        super("Too Many row/col",
+        super("BTSP-CONT-0006",
+                "Too Many row/col",
                 "",
                 "edu/rpi/legup/images/battleship/contradictions/too_many_segments.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/battleship/rules/battleship_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/rules/battleship_reference_sheet.txt
@@ -1,0 +1,17 @@
+BTSP-BASC-0001 : ContinueShipBasicRule
+BTSP-BASC-0002 : FinishedWithShipsBasicRule
+BTSP-BASC-0003 : FinishWithWaterBasicRule
+BTSP-BASC-0004 : SegmentTypeBasicRule
+BTSP-BASC-0005 : SurroundShipBasicRule
+
+BTSP-CONT-0001 : AdjacentShipsContradictionRule
+BTSP-CONT-0002 : IncompleteShipContradictionRule
+BTSP-CONT-0003 : TooFewInFleetContradictionRule
+BTSP-CONT-0004 : TooFewRowColContradictionRule
+BTSP-CONT-0005 : TooManyInFleetContradictionRule
+BTSP-CONT-0006 : TooManyRowColContradiction
+
+BTSP-CASE-0001 : SegmentTypeCaseRule
+BTSP-CASE-0002 : ShipLocationCaseRule
+BTSP-CASE-0003 : ShipOrWaterCaseRule
+

--- a/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/BlackOrWhiteCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/BlackOrWhiteCaseRule.java
@@ -14,7 +14,8 @@ import java.util.List;
 
 public class BlackOrWhiteCaseRule extends CaseRule {
     public BlackOrWhiteCaseRule() {
-        super("Black or White",
+        super("FPIX-CASE-0001",
+                "Black or White",
                 "Each cell is either black or white.",
                 "edu/rpi/legup/images/fillapix/cases/BlackOrWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/FinishWithBlackBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/FinishWithBlackBasicRule.java
@@ -11,7 +11,8 @@ import edu.rpi.legup.puzzle.fillapix.FillapixCellType;
 
 public class FinishWithBlackBasicRule extends BasicRule {
     public FinishWithBlackBasicRule() {
-        super("Finish with Black",
+        super("FPIX-BASC-0001",
+                "Finish with Black",
                 "The remaining unknowns around and on a cell must be black to satisfy the number",
                 "edu/rpi/legup/images/fillapix/rules/FinishWithBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/FinishWithWhiteBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/FinishWithWhiteBasicRule.java
@@ -11,7 +11,8 @@ import edu.rpi.legup.puzzle.fillapix.FillapixCellType;
 
 public class FinishWithWhiteBasicRule extends BasicRule {
     public FinishWithWhiteBasicRule() {
-        super("Finish with White",
+        super("FinishWithWhiteBasicRule",
+                "Finish with White",
                 "The remaining unknowns around and on a cell must be white to satisfy the number",
                 "edu/rpi/legup/images/fillapix/rules/FinishWithWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/TooFewBlackCellsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/TooFewBlackCellsContradictionRule.java
@@ -12,7 +12,8 @@ import java.awt.*;
 public class TooFewBlackCellsContradictionRule extends ContradictionRule {
 
     public TooFewBlackCellsContradictionRule() {
-        super("Too Few Black Cells",
+        super("FPIX-CONT-0001",
+                "Too Few Black Cells",
                 "There may not be fewer black cells than the number.",
                 "edu/rpi/legup/images/fillapix/contradictions/TooFewBlackCells.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/TooManyBlackCellsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/TooManyBlackCellsContradictionRule.java
@@ -12,7 +12,8 @@ import java.awt.*;
 public class TooManyBlackCellsContradictionRule extends ContradictionRule {
 
     public TooManyBlackCellsContradictionRule() {
-        super("Too Many Black Cells",
+        super("FPIX-CONT-0002",
+                "Too Many Black Cells",
                 "There may not be more black cells than the number",
                 "edu/rpi/legup/images/fillapix/contradictions/TooManyBlackCells.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/fillapix_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/fillapix/rules/fillapix_reference_sheet.txt
@@ -1,0 +1,7 @@
+FPIX-BASC-0001 : FinishWithBlackBasicRule
+FPIX-BASC-0002 : FinishWithWhiteBasicRule
+
+FPIX-CONT-0001 : TooFewBlackCellsContradictionRule
+FPIX-CONT-0002 : TooManyBlackCellsContradictionRule
+
+FPIX-CASE-0001 : BlackOrWhiteCaseRule

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/AdjacentBlacksContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/AdjacentBlacksContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class AdjacentBlacksContradictionRule extends ContradictionRule {
 
     public AdjacentBlacksContradictionRule() {
-        super("Adjacent Blacks",
+        super("HEYA-CONT-0001", "Adjacent Blacks",
                 "",
                 "edu/rpi/legup/images/heyawake/contradictions/adjacentBlacks.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/BlackOrWhiteCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/BlackOrWhiteCaseRule.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class BlackOrWhiteCaseRule extends CaseRule {
 
     public BlackOrWhiteCaseRule() {
-        super("Black or White",
+        super("HEYA-CASE-0001", "Black or White",
                 "",
                 "edu/rpi/legup/images/heyawake/cases/BlackOrWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/BlackPathBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/BlackPathBasicRule.java
@@ -1,4 +1,8 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
 public class BlackPathBasicRule {
+    public BlackPathBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/BottleNeckBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/BottleNeckBasicRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class BottleNeckBasicRule {
+public class BottleNeckBasicRule
+{
+    public BottleNeckBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/FillRoomBlackBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/FillRoomBlackBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class FillRoomBlackBasicRule extends BasicRule {
 
     public FillRoomBlackBasicRule() {
-        super("Fill Room Black",
+        super("HEYA-BASC-0003", "Fill Room Black",
                 "",
                 "edu/rpi/legup/images/heyawake/rules/FillRoomBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/FillRoomWhiteBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/FillRoomWhiteBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class FillRoomWhiteBasicRule extends BasicRule {
 
     public FillRoomWhiteBasicRule() {
-        super("Fill Room White",
+        super("HEYA-BASC-0004", "Fill Room White",
                 "",
                 "edu/rpi/legup/images/heyawake/rules/FillRoomWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/OneRowBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/OneRowBasicRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class OneRowBasicRule {
+public class OneRowBasicRule
+{
+    public OneRowBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/PreventWhiteLineBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/PreventWhiteLineBasicRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class PreventWhiteLineBasicRule {
+public class PreventWhiteLineBasicRule
+{
+    public PreventWhiteLineBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/RoomTooEmptyContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/RoomTooEmptyContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class RoomTooEmptyContradictionRule extends ContradictionRule {
 
     public RoomTooEmptyContradictionRule() {
-        super("Room too Empty",
+        super("HEYA-CONT-0002", "Room too Empty",
                 "",
                 "edu/rpi/legup/images/heyawake/contradictions/RoomTooEmpty.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/RoomTooFullContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/RoomTooFullContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class RoomTooFullContradictionRule extends ContradictionRule {
 
     public RoomTooFullContradictionRule() {
-        super("Room too Full",
+        super("HEYA-CONT-0003", "Room too Full",
                 "",
                 "edu/rpi/legup/images/heyawake/contradictions/RoomTooFull.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/ThreeByThreeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/ThreeByThreeBasicRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class ThreeByThreeBasicRule {
+public class ThreeByThreeBasicRule
+{
+    public ThreeByThreeBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/TwoInCornerBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/TwoInCornerBasicRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class TwoInCornerBasicRule {
+public class TwoInCornerBasicRule
+{
+    public TwoInCornerBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteAreaContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteAreaContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class WhiteAreaContradictionRule extends ContradictionRule {
 
     public WhiteAreaContradictionRule() {
-        super("White Area",
+        super("HEYA-CONT-0004", "White Area",
                 "",
                 "edu/rpi/legup/images/heyawake/contradictions/WhiteArea.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteAroundBlackBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteAroundBlackBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class WhiteAroundBlackBasicRule extends BasicRule {
 
     public WhiteAroundBlackBasicRule() {
-        super("White Around Black",
+        super("HEYA-BASC-0009", "White Around Black",
                 "",
                 "edu/rpi/legup/images/heyawake/rules/WhiteAroundBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteEscapeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteEscapeBasicRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class WhiteEscapeBasicRule {
+public class WhiteEscapeBasicRule
+{
+    public WhiteEscapeBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteLineContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/WhiteLineContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class WhiteLineContradictionRule extends ContradictionRule {
 
     public WhiteLineContradictionRule() {
-        super("White Line",
+        super("HEYA-CONT-0005", "White Line",
                 "",
                 "edu/rpi/legup/images/heyawake/contradictions/WhiteLine.png");
 

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/ZigZagCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/ZigZagCaseRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class ZigZagCaseRule {
+public class ZigZagCaseRule
+{
+    public ZigZagCaseRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/ZigZagWhiteBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/ZigZagWhiteBasicRule.java
@@ -1,4 +1,9 @@
 package edu.rpi.legup.puzzle.heyawake.rules;
 
-public class ZigZagWhiteBasicRule {
+public class ZigZagWhiteBasicRule
+{
+    public ZigZagWhiteBasicRule()
+    {
+        throw new RuntimeException("This rule has not been implemented");
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/heyawake_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/rules/heyawake_reference_sheet.txt
@@ -1,0 +1,20 @@
+HEYA-BASC-0001 : BlackPathBasicRule
+HEYA-BASC-0002 : BottleNeckBasicRule
+HEYA-BASC-0003 : FillRoomBlackBasicRule
+HEYA-BASC-0004 : FillRoomWhiteBasicRule
+HEYA-BASC-0005 : OneRowBasicRule
+HEYA-BASC-0006 : PreventWhiteLineBasicRule
+HEYA-BASC-0007 : ThreeByThreeBasicRule
+HEYA-BASC-0008 : TwoInCornerBasicRule
+HEYA-BASC-0009 : WhiteAroundBlackBasicRule
+HEYA-BASC-0010 : WhiteEscapeBasicRule
+HEYA-BASC-0011 : ZigZagWhiteBasicRule
+
+HEYA-CONT-0001 : AdjacentBlacksContradictionRule
+HEYA-CONT-0002 : RoomTooEmptyContradictionRule
+HEYA-CONT-0003 : RoomTooFullContradictionRule
+HEYA-CONT-0004 : WhiteAreaContradictionRule
+HEYA-CONT-0005 : WhiteLineContradictionRule
+
+HEYA-CASE-0001 : BlackOrWhiteCaseRule
+HEYA-CASE-0002 : ZigZagCaseRule

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/BulbsInPathContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/BulbsInPathContradictionRule.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public class BulbsInPathContradictionRule extends ContradictionRule {
 
     public BulbsInPathContradictionRule() {
-        super("Bulbs In Path",
+        super("LTUP-CONT-0001","Bulbs In Path",
                 "A bulb cannot be placed in another bulb's path.",
                 "edu/rpi/legup/images/lightup/contradictions/BulbsInPath.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/BulbsOutsideDiagonalBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/BulbsOutsideDiagonalBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class BulbsOutsideDiagonalBasicRule extends BasicRule {
 
     public BulbsOutsideDiagonalBasicRule() {
-        super("Bulbs Outside Diagonal",
+        super("LTUP-BASC-0001", "Bulbs Outside Diagonal",
                 "Cells on the external edges of a 3 diagonal to a numerical block must be bulbs.",
                 "edu/rpi/legup/images/lightup/rules/BulbsOutsideDiagonal.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/CannotLightACellContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/CannotLightACellContradictionRule.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public class CannotLightACellContradictionRule extends ContradictionRule {
 
     public CannotLightACellContradictionRule() {
-        super("Cannot Light A Cell",
+        super("LTUP-CONT-0002", "Cannot Light A Cell",
                 "All cells must be able to be lit.",
                 "edu/rpi/legup/images/lightup/contradictions/CannotLightACell.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/EmptyCellinLightBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/EmptyCellinLightBasicRule.java
@@ -12,7 +12,7 @@ import edu.rpi.legup.puzzle.lightup.LightUpCellType;
 public class EmptyCellinLightBasicRule extends BasicRule {
 
     public EmptyCellinLightBasicRule() {
-        super("Empty Cells in Light",
+        super("LTUP-BASC-0002", "Empty Cells in Light",
                 "Cells in light must be empty.",
                 "edu/rpi/legup/images/lightup/rules/EmptyCellInLight.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/EmptyCornersBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/EmptyCornersBasicRule.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class EmptyCornersBasicRule extends BasicRule {
 
     public EmptyCornersBasicRule() {
-        super("Empty Corners",
+        super("LTUP-BASC-0003", "Empty Corners",
                 "Cells on the corners of a number must be empty if placing bulbs would prevent the number from being satisfied.",
                 "edu/rpi/legup/images/lightup/rules/EmptyCorners.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/FinishWithBulbsBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/FinishWithBulbsBasicRule.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class FinishWithBulbsBasicRule extends BasicRule {
 
     public FinishWithBulbsBasicRule() {
-        super("Finish with Bulbs",
+        super("LTUP-BASC-0004", "Finish with Bulbs",
                 "The remaining unknowns around a block must be bulbs to satisfy the number.",
                 "edu/rpi/legup/images/lightup/rules/FinishWithBulbs.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/FinishWithEmptyBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/FinishWithEmptyBasicRule.java
@@ -14,7 +14,7 @@ import java.awt.*;
 public class FinishWithEmptyBasicRule extends BasicRule {
 
     public FinishWithEmptyBasicRule() {
-        super("Finish with Empty",
+        super("LTUP-BASC-0005", "Finish with Empty",
                 "The remaining unknowns around a block must be empty if the number is satisfied.",
                 "edu/rpi/legup/images/lightup/rules/FinishWithEmpty.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/LightOrEmptyCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/LightOrEmptyCaseRule.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class LightOrEmptyCaseRule extends CaseRule {
 
     public LightOrEmptyCaseRule() {
-        super("Light or Empty",
+        super("LTUP-CASE-0001", "Light or Empty",
                 "Each blank cell is either a light or empty.",
                 "edu/rpi/legup/images/lightup/cases/LightOrEmpty.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
@@ -14,7 +14,7 @@ import java.awt.*;
 public class MustLightBasicRule extends BasicRule {
 
     public MustLightBasicRule() {
-        super("Must Light",
+        super("LTUP-BASC-0006", "Must Light",
                 "A cell must be a bulb if it is the only cell to be able to light another.",
                 "edu/rpi/legup/images/lightup/rules/MustLight.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/SatisfyNumberCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/SatisfyNumberCaseRule.java
@@ -19,7 +19,7 @@ import java.util.Set;
 public class SatisfyNumberCaseRule extends CaseRule {
 
     public SatisfyNumberCaseRule() {
-        super("Satisfy Number",
+        super("LTUP-CASE-0002", "Satisfy Number",
                 "The different ways a blocks number can be satisfied.",
                 "edu/rpi/legup/images/lightup/cases/SatisfyNumber.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/TooFewBulbsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/TooFewBulbsContradictionRule.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public class TooFewBulbsContradictionRule extends ContradictionRule {
 
     public TooFewBulbsContradictionRule() {
-        super("Too Few Bulbs",
+        super("LTUP-CONT-0003", "Too Few Bulbs",
                 "There cannot be less bulbs around a block than its number states.",
                 "edu/rpi/legup/images/lightup/contradictions/TooFewBulbs.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/TooManyBulbsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/TooManyBulbsContradictionRule.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public class TooManyBulbsContradictionRule extends ContradictionRule {
 
     public TooManyBulbsContradictionRule() {
-        super("Too Many Bulbs",
+        super("LTUP-CONT-0004", "Too Many Bulbs",
                 "There cannot be more bulbs around a block than its number states.",
                 "edu/rpi/legup/images/lightup/contradictions/TooManyBulbs.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/lightup_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/lightup_reference_sheet.txt
@@ -1,0 +1,14 @@
+LTUP-BASC-0001 : BulbsOutsideDiagonalBasicRule
+LTUP-BASC-0002 : EmptyCellInLightBasicRule
+LTUP-BASC-0003 : EmptyCornersBasicRule
+LTUP-BASC-0004 : FinishWithBulbsBasicRule
+LTUP-BASC-0005 : FinishWithEmptyBasicRule
+LTUP-BASC-0006 : MustLightBasicRule
+
+LTUP-CONT-0001 : BulbsInPathContradictionRule
+LTUP-CONT-0002 : CannotLightACellContradictionRule
+LTUP-CONT-0003 : TooFewBulbsContradictionRule
+LTUP-CONT-0004 : TooManyBulbsContradictionRule
+
+LTUP-CASE-0001 : LightOrEmptyCaseRule
+LTUP-CASE-0002 : SatisfyNumberCaseRule

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BadLoopingContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BadLoopingContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class BadLoopingContradictionRule extends ContradictionRule {
 
     public BadLoopingContradictionRule() {
-        super("Bad Looping",
+        super("MASY-CONT-0001", "Bad Looping",
                 "",
                 "edu/rpi/legup/images/masyu/ContradictionBadLooping.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlackContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlackContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class BlackContradictionRule extends ContradictionRule {
 
     public BlackContradictionRule() {
-        super("Black",
+        super("MASY-CONT-0002", "Black",
                 "",
                 "edu/rpi/legup/images/masyu/ContradictionBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlackEdgeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlackEdgeBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class BlackEdgeBasicRule extends BasicRule {
 
     public BlackEdgeBasicRule() {
-        super("Black Edge",
+        super("MASY-BASC-0001", "Black Edge",
                 "",
                 "edu/rpi/legup/images/masyu/RuleBlackEdge.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlackSplitCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlackSplitCaseRule.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class BlackSplitCaseRule extends CaseRule {
 
     public BlackSplitCaseRule() {
-        super("Black Split",
+        super("MASY-CASE-0001", "Black Split",
                 "",
                 "edu/rpi/legup/images/masyu/CaseBlackSplit.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlockedBlackBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/BlockedBlackBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class BlockedBlackBasicRule extends BasicRule {
 
     public BlockedBlackBasicRule() {
-        super("Blocked Black",
+        super("MASY-BASC-0002","Blocked Black",
                 "",
                 "edu/rpi/legup/images/masyu/RuleBlockedBlack.gif");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/ConnectedCellsBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/ConnectedCellsBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class ConnectedCellsBasicRule extends BasicRule {
 
     public ConnectedCellsBasicRule() {
-        super("Connected Cells",
+        super("MASY-BASC-0003", "Connected Cells",
                 "",
                 "edu/rpi/legup/images/masyu/RuleConnectedCells.gif");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/FinishPathBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/FinishPathBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class FinishPathBasicRule extends BasicRule {
 
     public FinishPathBasicRule() {
-        super("Finished Path",
+        super("MASY-BASC-0004", "Finished Path",
                 "",
                 "edu/rpi/legup/images/masyu/RuleFinishPath.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/NearWhiteBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/NearWhiteBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class NearWhiteBasicRule extends BasicRule {
 
     public NearWhiteBasicRule() {
-        super("Near White",
+        super("MASY-BASC-0005", "Near White",
                 "",
                 "edu/rpi/legup/images/masyu/RuleNearWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/NoOptionsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/NoOptionsContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class NoOptionsContradictionRule extends ContradictionRule {
 
     public NoOptionsContradictionRule() {
-        super("No Options",
+        super("MASY-CONT-0003","No Options",
                 "",
                 "edu/rpi/legup/images/masyu/ContradictionNoOptions.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/NormalSplitCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/NormalSplitCaseRule.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class NormalSplitCaseRule extends CaseRule {
 
     public NormalSplitCaseRule() {
-        super("Normal Split",
+        super("MASY-CASE-0002", "Normal Split",
                 "",
                 "edu/rpi/legup/images/masyu/CaseNormalSplit.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/OnlyOneChoiceBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/OnlyOneChoiceBasicRule.java
@@ -9,7 +9,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 public class OnlyOneChoiceBasicRule extends BasicRule {
 
     public OnlyOneChoiceBasicRule() {
-        super("Only One Choice",
+        super("MASY-BASC-0006", "Only One Choice",
                 "",
                 "edu/rpi/legup/images/masyu/RuleOnlyOneChoice.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/OnlyTwoContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/OnlyTwoContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class OnlyTwoContradictionRule extends ContradictionRule {
 
     public OnlyTwoContradictionRule() {
-        super("Only Two",
+        super("MASY-CONT-0004", "Only Two",
                 "",
                 "edu/rpi/legup/images/masyu/ContradictionOnly2.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/WhiteContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/WhiteContradictionRule.java
@@ -7,7 +7,7 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 public class WhiteContradictionRule extends ContradictionRule {
 
     public WhiteContradictionRule() {
-        super("White",
+        super("MASY-CONT-0005", "White",
                 "",
                 "edu/rpi/legup/images/masyu/ContradictionWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/WhiteEdgeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/WhiteEdgeBasicRule.java
@@ -8,7 +8,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 
 public class WhiteEdgeBasicRule extends BasicRule {
     public WhiteEdgeBasicRule() {
-        super("White Edge",
+        super("MASY-BASC-0007", "White Edge",
                 "",
                 "edu/rpi/legup/images/masyu/RuleWhiteEdge.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/WhiteSplitCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/WhiteSplitCaseRule.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class WhiteSplitCaseRule extends CaseRule {
 
     public WhiteSplitCaseRule() {
-        super("White Split",
+        super("MASY-CASE-0003","White Split",
                 "",
                 "edu/rpi/legup/images/masyu/CaseWhiteSplit.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/rules/masyu_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/rules/masyu_reference_sheet.txt
@@ -1,0 +1,17 @@
+MASY-BASC-0001 : BlackEdgeBasicRule
+MASY-BASC-0002 : BlockedBlackBasicRule
+MASY-BASC-0003 : ConnectedCellsBasicRule
+MASY-BASC-0004 : FinishPathBasicRule
+MASY-BASC-0005 : NearWhiteBasicRule
+MASY-BASC-0006 : OnlyOneChoiceBasicRule
+MASY-BASC-0007 : WhiteEdgeBasicRule
+
+MASY-CONT-0001 : BadLoopingContradictionRule
+MASY-CONT-0002 : BlackContradictionRule
+MASY-CONT-0003 : NoOptionsContradictionRule
+MASY-CONT-0004 : OnlyTwoContradictionRule
+MASY-CONT-0005 : WhiteContradictionRule
+
+MASY-CASE-0001 : BlackSplitCaseRule
+MASY-CASE-0002 : NormalSplitCaseRule
+MASY-CASE-0003 : WhiteSplitCaseRule

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackBetweenRegionsBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackBetweenRegionsBasicRule.java
@@ -19,7 +19,8 @@ import java.util.Set;
 public class BlackBetweenRegionsBasicRule extends BasicRule {
 
     public BlackBetweenRegionsBasicRule() {
-        super("Black Between Regions",
+        super("NURIK-BASIC-00001",
+                "Black Between Regions",
                 "Any unknowns between two regions must be black.",
                 "edu/rpi/legup/images/nurikabe/rules/BetweenRegions.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackBottleNeckBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackBottleNeckBasicRule.java
@@ -13,7 +13,8 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeType;
 public class BlackBottleNeckBasicRule extends BasicRule {
 
     public BlackBottleNeckBasicRule() {
-        super("Black Bottle Neck",
+        super("NURIK-BASIC-00002",
+                "Black Bottle Neck",
                 "If there is only one path for a black to escape, then those unknowns must be white.",
                 "edu/rpi/legup/images/nurikabe/rules/OneUnknownBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackOrWhiteCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackOrWhiteCaseRule.java
@@ -15,7 +15,8 @@ import java.util.List;
 public class BlackOrWhiteCaseRule extends CaseRule {
 
     public BlackOrWhiteCaseRule() {
-        super("Black or White",
+        super("NURI-CASE-0001",
+                "Black or White",
                 "Each blank cell is either black or white.",
                 "edu/rpi/legup/images/nurikabe/cases/BlackOrWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackSquareContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/BlackSquareContradictionRule.java
@@ -13,7 +13,8 @@ public class BlackSquareContradictionRule extends ContradictionRule {
     private final String INVALID_USE_MESSAGE = "Does not contain a contradiction at this index";
 
     public BlackSquareContradictionRule() {
-        super("Black Square",
+        super("NURI-CONT-0001",
+                "Black Square",
                 "There cannot be a 2x2 square of black.",
                 "edu/rpi/legup/images/nurikabe/contradictions/BlackSquare.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CantReachWhiteContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CantReachWhiteContradictionRule.java
@@ -17,7 +17,8 @@ public class CantReachWhiteContradictionRule extends ContradictionRule {
     private final String INVALID_USE_MESSAGE = "Does not contain a contradiction at this index";
 
     public CantReachWhiteContradictionRule() {
-        super("Cant Reach white cell",
+        super("NURI-CONT-0002",
+                "Unreachables are Black",
                 "A white cell must be able to reach a white region",
                 "edu/rpi/legup/images/nurikabe/contradictions/CantReach.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CornerBlackBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CornerBlackBasicRule.java
@@ -18,7 +18,8 @@ import java.util.Set;
 public class CornerBlackBasicRule extends BasicRule {
 
     public CornerBlackBasicRule() {
-        super("Corners Black",
+        super("NURI-BASC-0003",
+                "Corners Black",
                 "If there is only one white square connected to unknowns and one more white is needed then the angles of that white square are black",
                 "edu/rpi/legup/images/nurikabe/rules/CornerBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/FillinBlackBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/FillinBlackBasicRule.java
@@ -13,7 +13,8 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeType;
 public class FillinBlackBasicRule extends BasicRule {
 
     public FillinBlackBasicRule() {
-        super("Fill In Black",
+        super("NURI-BASC-0004",
+                "Fill In Black",
                 "If there an unknown region surrounded by black, it must be black.",
                 "edu/rpi/legup/images/nurikabe/rules/FillInBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/FillinWhiteBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/FillinWhiteBasicRule.java
@@ -13,7 +13,8 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeType;
 public class FillinWhiteBasicRule extends BasicRule {
 
     public FillinWhiteBasicRule() {
-        super("Fill In White",
+        super("NURI-BASC-0005",
+                "Fill In White",
                 "If there an unknown region surrounded by white, it must be white.",
                 "edu/rpi/legup/images/nurikabe/rules/FillInWhite.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/IsolateBlackContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/IsolateBlackContradictionRule.java
@@ -17,7 +17,8 @@ public class IsolateBlackContradictionRule extends ContradictionRule {
     private final String INVALID_USE_MESSAGE = "Contradiction must be a black cell";
 
     public IsolateBlackContradictionRule() {
-        super("Isolated Black",
+        super("NURI-CONT-0003",
+                "Isolated Black",
                 "There must still be a possibility to connect every Black cell",
                 "edu/rpi/legup/images/nurikabe/contradictions/BlackArea.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/MultipleNumbersContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/MultipleNumbersContradictionRule.java
@@ -17,7 +17,8 @@ public class MultipleNumbersContradictionRule extends ContradictionRule {
     private final String INVALID_USE_MESSAGE = "Contradiction must be a numbered cell";
 
     public MultipleNumbersContradictionRule() {
-        super("Multiple Numbers",
+        super("NURI-CONT-0004",
+                "Multiple Numbers",
                 "All white regions cannot have more than one number.",
                 "edu/rpi/legup/images/nurikabe/contradictions/MultipleNumbers.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/NoNumberContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/NoNumberContradictionRule.java
@@ -18,7 +18,8 @@ public class NoNumberContradictionRule extends ContradictionRule {
     private final String NOT_SURROUNDED_BY_BLACK_MESSAGE = "Must be surrounded by black cells";
 
     public NoNumberContradictionRule() {
-        super("No Number",
+        super("NURI-CONT-0005",
+                "No Number",
                 "All enclosed white regions must have a number.",
                 "edu/rpi/legup/images/nurikabe/contradictions/NoNumber.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/PreventBlackSquareBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/PreventBlackSquareBasicRule.java
@@ -13,7 +13,8 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeType;
 public class PreventBlackSquareBasicRule extends BasicRule {
 
     public PreventBlackSquareBasicRule() {
-        super("Prevent Black Square",
+        super("NURI-BASC-0006",
+                "Prevent Black Square",
                 "There cannot be a 2x2 square of black. (3 blacks = fill in last corner white)",
                 "edu/rpi/legup/images/nurikabe/rules/NoBlackSquare.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/SurroundRegionBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/SurroundRegionBasicRule.java
@@ -13,7 +13,7 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeType;
 public class SurroundRegionBasicRule extends BasicRule {
 
     public SurroundRegionBasicRule() {
-        super("Surround Region",
+        super("NURI-BASC-0007","Surround Region",
                 "Surround Region",
                 "edu/rpi/legup/images/nurikabe/rules/SurroundBlack.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/TooFewSpacesContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/TooFewSpacesContradictionRule.java
@@ -17,7 +17,8 @@ public class TooFewSpacesContradictionRule extends ContradictionRule {
     private final String INVALID_USE_MESSAGE = "Contradiction must be a white or a numbered cell";
 
     public TooFewSpacesContradictionRule() {
-        super("Too Few Spaces",
+        super("NURI-CONT-0006",
+                "Too Few Spaces",
                 "A region cannot contain less spaces than its number.",
                 "edu/rpi/legup/images/nurikabe/contradictions/TooFewSpaces.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/TooManySpacesContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/TooManySpacesContradictionRule.java
@@ -18,7 +18,8 @@ public class TooManySpacesContradictionRule extends ContradictionRule {
     private final String INVALID_USE_MESSAGE = "Contradiction must be a white or a numbered cell";
 
     public TooManySpacesContradictionRule() {
-        super("Too Many Spaces",
+        super("NURI-CONT-0007",
+                "Too Many Spaces",
                 "A region cannot contain more spaces than its number.",
                 "edu/rpi/legup/images/nurikabe/contradictions/TooManySpaces.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableBasicRule.java
@@ -12,7 +12,8 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeType;
 
 public class UnreachableBasicRule extends BasicRule {
     public UnreachableBasicRule() {
-        super("Unreachable white region",
+        super("NURI-BASC-0008",
+                "Unreachable white region",
                 "A cell must be black if it cannot be reached by any white region",
                 "edu/rpi/legup/images/nurikabe/rules/Unreachable.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/WhiteBottleNeckBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/WhiteBottleNeckBasicRule.java
@@ -16,7 +16,8 @@ import java.util.Set;
 public class WhiteBottleNeckBasicRule extends BasicRule {
 
     public WhiteBottleNeckBasicRule() {
-        super("White Bottle Neck",
+        super("NURI-BASC-0009",
+                "White Bottle Neck",
                 "If a region needs more whites and there is only one path for the region to expand, then those unknowns must be white.", "edu/rpi/legup/images/nurikabe/rules/OneUnknownWhite.png");
     }
 

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/nurikabe_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/nurikabe_reference_sheet.txt
@@ -1,0 +1,19 @@
+NURI-BASC-0001 : BlackBetweenRegionsBasicRule
+NURI-BASC-0002 : BlackBottleNeckBasicRule
+NURI-BASC-0003 : CornerBlackBasicRule
+NURI-BASC-0004 : FillinBlackBasicRule
+NURI-BASC-0005 : FillinWhiteBasicRule
+NURI-BASC-0006 : PreventBlackSquareBasicRule
+NURI-BASC-0007 : SurroundRegionBasicRule
+NURI-BASC-0008 : UnreachableBasicRule
+NURI-BASC-0009 : WhiteBottleNeckBasicRule
+
+NURI-CONT-0001 : BlackSquareContradictionRule
+NURI-CONT-0002 : CantReachWhiteContradictionRule
+NURI-CONT-0003 : IsolateBlackContradictionRule
+NURI-CONT-0004 : MultipleNumbersContradictionRule
+NURI-CONT-0005 : NoNumberContradictionRule
+NURI-CONT-0006 : TooFewSpacesContradictionRule
+NURI-CONT-0007 : TooManySpacesContradictionRule
+
+NURI-CASE-0001 : BlackOrWhiteCaseRule

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/BasicRuleAtomic.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/BasicRuleAtomic.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleAtomic extends BasicRule_Generic{
     
     public BasicRuleAtomic(){
-        super("Atomic Rule",
+        super("STTT-BASC-0001", "Atomic Rule",
                 "All identical atoms have the same T/F value",
                 "Atomic",
                 new ContradictionRuleAtomic(),

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleAndElimination.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleAndElimination.java
@@ -5,8 +5,8 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleAndElimination extends BasicRule_GenericElimination {
 
     public BasicRuleAndElimination() {
-        super("And", new ContradictionRuleAnd());
-        //System.out.println("and elimination constructor");
+        super("STTT-BASC-0002", "And", new ContradictionRuleAnd());
+        System.out.println("and eliminatio constructor");
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleBiconditionalElimination.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleBiconditionalElimination.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleBiconditionalElimination extends BasicRule_GenericElimination {
 
     public BasicRuleBiconditionalElimination() {
-        super("Biconditional", new ContradictionRuleBiconditional());
+        super("STTT-BASC-0003", "Biconditional", new ContradictionRuleBiconditional());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleConditionalElimination.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleConditionalElimination.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleConditionalElimination extends BasicRule_GenericElimination {
 
     public BasicRuleConditionalElimination() {
-        super("Conditional", new ContradictionRuleConditional());
+        super("STTT-BASC-0004", "Conditional", new ContradictionRuleConditional());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleNotElimination.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleNotElimination.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleNotElimination extends BasicRule_GenericElimination {
 
     public BasicRuleNotElimination() {
-        super("Not", new ContradictionRuleNot());
+        super("STTT-BASC-0005", "Not", new ContradictionRuleNot());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleOrElimination.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRuleOrElimination.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleOrElimination extends BasicRule_GenericElimination {
 
     public BasicRuleOrElimination() {
-        super("Or", new ContradictionRuleOr());
+        super("STTT-BASC-0006", "Or", new ContradictionRuleOr());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRule_GenericElimination.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/elimination/BasicRule_GenericElimination.java
@@ -5,9 +5,9 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 
 public abstract class BasicRule_GenericElimination extends BasicRule_Generic {
 
-    public BasicRule_GenericElimination(String ruleName, ContradictionRule contradictionRule) {
+    public BasicRule_GenericElimination(String ruleID, String ruleName, ContradictionRule contradictionRule) {
 
-        super(ruleName+" Elimination",
+        super(ruleID,ruleName+" Elimination",
                 ruleName+" statements must have a valid pattern",
                 "elimination/"+ruleName,
                 contradictionRule,

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleAndIntroduction.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleAndIntroduction.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleAndIntroduction extends BasicRule_GenericIntroduction {
 
     public BasicRuleAndIntroduction() {
-        super("And", new ContradictionRuleAnd());
+        super("STTT-BASC-0007", "And", new ContradictionRuleAnd());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleBiconditionalIntroduction.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleBiconditionalIntroduction.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleBiconditionalIntroduction extends BasicRule_GenericIntroduction {
 
     public BasicRuleBiconditionalIntroduction() {
-        super("Biconditional", new ContradictionRuleBiconditional());
+        super("STTT-BASC-0008", "Biconditional", new ContradictionRuleBiconditional());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleConditionalIntroduction.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleConditionalIntroduction.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleConditionalIntroduction extends BasicRule_GenericIntroduction {
 
     public BasicRuleConditionalIntroduction() {
-        super("Conditional", new ContradictionRuleConditional());
+        super("STTT-BASC-0009", "Conditional", new ContradictionRuleConditional());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleNotIntroduction.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleNotIntroduction.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleNotIntroduction extends BasicRule_GenericIntroduction {
 
     public BasicRuleNotIntroduction() {
-        super("Not", new ContradictionRuleNot());
+        super("STTT-BASC-0010", "Not", new ContradictionRuleNot());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleOrIntroduction.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRuleOrIntroduction.java
@@ -5,7 +5,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.rules.contradiction.ContradictionRul
 public class BasicRuleOrIntroduction extends BasicRule_GenericIntroduction {
 
     public BasicRuleOrIntroduction() {
-        super("Or", new ContradictionRuleOr());
+        super("STTT-BASC-0011", "Or", new ContradictionRuleOr());
     }
 
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRule_GenericIntroduction.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/basic/introduction/BasicRule_GenericIntroduction.java
@@ -5,9 +5,9 @@ import edu.rpi.legup.model.rules.ContradictionRule;
 
 public abstract class BasicRule_GenericIntroduction extends BasicRule_Generic {
 
-    protected BasicRule_GenericIntroduction(String ruleName, ContradictionRule contradictionRule) {
+    protected BasicRule_GenericIntroduction(String ruleID, String ruleName, ContradictionRule contradictionRule) {
 
-        super(ruleName+" Introduction",
+        super(ruleID,ruleName+" Introduction",
                 ruleName+" statements must have a valid pattern",
                 "introduction/"+ruleName,
                 contradictionRule,

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleAnd.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleAnd.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class CaseRuleAnd extends CaseRule_GenericStatement {
 
     public CaseRuleAnd() {
-        super(ShortTruthTableOperation.AND,
+        super("STTT-CASE-0001", ShortTruthTableOperation.AND,
                 "And",
                 trueCases,
                 falseCases);

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleAtomic.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleAtomic.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class CaseRuleAtomic extends CaseRule_Generic {
 
     public CaseRuleAtomic() {
-        super("Atomic",
+        super("STTT-CASE-0002", "Atomic",
                 "Atomic Case",
                 "Each unknown cell must either be true or false");
         System.out.println("Case Rule T/F constructor");

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleBiconditional.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleBiconditional.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class CaseRuleBiconditional extends CaseRule_GenericStatement {
 
     public CaseRuleBiconditional() {
-        super(ShortTruthTableOperation.BICONDITIONAL,
+        super("STTT-CASE-0003", ShortTruthTableOperation.BICONDITIONAL,
                 "Biconditional",
                 trueCases,
                 falseCases);

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleConditional.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleConditional.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class CaseRuleConditional extends CaseRule_GenericStatement {
 
     public CaseRuleConditional() {
-        super(ShortTruthTableOperation.CONDITIONAL,
+        super("STTT-CASE-0004", ShortTruthTableOperation.CONDITIONAL,
                 "Conditional",
                 trueCases,
                 falseCases);

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleOr.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRuleOr.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class CaseRuleOr extends CaseRule_GenericStatement {
 
     public CaseRuleOr() {
-        super(ShortTruthTableOperation.OR,
+        super("STTT-CASE-0005", ShortTruthTableOperation.OR,
                 "Or",
                 trueCases,
                 falseCases);

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRule_Generic.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRule_Generic.java
@@ -18,9 +18,8 @@ import java.util.List;
 
 public abstract class CaseRule_Generic extends CaseRule {
 
-    public CaseRule_Generic(String ruleName, String title, String description)
-    {
-        super(title, description, "edu/rpi/legup/images/shorttruthtable/ruleimages/case/"+ruleName+".png");
+    public CaseRule_Generic(String ruleID, String ruleName, String title, String description) {
+        super(ruleID, title, description, "edu/rpi/legup/images/shorttruthtable/ruleimages/case/"+ruleName+".png");
     }
 
 

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRule_GenericStatement.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/caserule/CaseRule_GenericStatement.java
@@ -15,10 +15,10 @@ import java.util.ArrayList;
 
 public abstract class CaseRule_GenericStatement extends CaseRule_Generic {
 
-    public CaseRule_GenericStatement(char operation, String title,
+    public CaseRule_GenericStatement(String ruleID, char operation, String title,
                                      ShortTruthTableCellType[][] trueCases,
                                      ShortTruthTableCellType[][] falseCases) {
-        super(ShortTruthTableOperation.getRuleName(operation),
+        super(ruleID, ShortTruthTableOperation.getRuleName(operation),
                 title+" case",
                 "A known "+title.toUpperCase()+" statement can have multiple forms");
 
@@ -40,7 +40,7 @@ public abstract class CaseRule_GenericStatement extends CaseRule_Generic {
     //Adds all elements that can be selected for this caserule
     @Override
     public CaseBoard getCaseBoard(Board board) {
-        //copy the board and add all ements that can be selected
+        //copy the board and add all elements that can be selected
         ShortTruthTableBoard sttBoard = (ShortTruthTableBoard) board.copy();
         sttBoard.setModifiable(false);
         CaseBoard caseBoard = new CaseBoard(sttBoard, this);

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleAnd.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleAnd.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class ContradictionRuleAnd extends ContradictionRule_GenericStatement{
 
     public ContradictionRuleAnd(){
-        super("Contradicting And",
+        super("STTT-CONT-0001", "Contradicting And",
                 "An AND statement must have a contradicting pattern",
                 "edu/rpi/legup/images/shorttruthtable/ruleimages/contradiction/And.png",
                 ShortTruthTableOperation.AND,

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleAtomic.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleAtomic.java
@@ -18,7 +18,7 @@ public class ContradictionRuleAtomic extends ContradictionRule{
 
 
     public ContradictionRuleAtomic(){
-        super("Contradicting Variable",
+        super("STTT-CONT-0002", "Contradicting Variable",
                 "A single variable can not be both True and False",
                 "edu/rpi/legup/images/shorttruthtable/ruleimages/contradiction/Atomic.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleBiconditional.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleBiconditional.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class ContradictionRuleBiconditional extends ContradictionRule_GenericStatement{
 
     public ContradictionRuleBiconditional(){
-        super("Contradicting Biconditional",
+        super("STTT-CONT-0002", "Contradicting Biconditional",
                 "A Biconditional statement must have a contradicting pattern",
                 "edu/rpi/legup/images/shorttruthtable/ruleimages/contradiction/Biconditional.png",
                 ShortTruthTableOperation.BICONDITIONAL,

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleConditional.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleConditional.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class ContradictionRuleConditional extends ContradictionRule_GenericStatement{
 
     public ContradictionRuleConditional(){
-        super("Contradicting Conditional",
+        super("STTT-CONT-0004", "Contradicting Conditional",
                 "A Conditional statement must have a contradicting pattern",
                 "edu/rpi/legup/images/shorttruthtable/ruleimages/contradiction/Conditional.png",
                 ShortTruthTableOperation.CONDITIONAL,

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleNot.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleNot.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class ContradictionRuleNot extends ContradictionRule_GenericStatement{
 
     public ContradictionRuleNot(){
-        super("Contradicting Negation",
+        super("STTT-CONT-0005", "Contradicting Negation",
                 "A negation and its following statement can not have the same truth value",
                 "edu/rpi/legup/images/shorttruthtable/ruleimages/contradiction/Not.png",
                 ShortTruthTableOperation.NOT,

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleOr.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRuleOr.java
@@ -6,7 +6,7 @@ import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableCellType;
 public class ContradictionRuleOr extends ContradictionRule_GenericStatement{
 
     public ContradictionRuleOr(){
-        super("Contradicting Or",
+        super("STTT-CONT-0006", "Contradicting Or",
                 "An OR statement must have a contradicting pattern",
                 "edu/rpi/legup/images/shorttruthtable/ruleimages/contradiction/Or.png",
                 ShortTruthTableOperation.OR,

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRule_GenericStatement.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/contradiction/ContradictionRule_GenericStatement.java
@@ -24,9 +24,9 @@ public abstract class ContradictionRule_GenericStatement extends ContradictionRu
     private final String NOT_RIGHT_OPERATOR_ERROR_MESSAGE = "This cell does not contain the correct operation";
     private final String NOT_TRUE_FALSE_ERROR_MESSAGE = "Can only check for a contradiction on a cell that is assigned a value of True or False";
 
-    public ContradictionRule_GenericStatement(String ruleName, String description, String imageName,
+    public ContradictionRule_GenericStatement(String ruleID, String ruleName, String description, String imageName,
                                               char operationSymbol, ShortTruthTableCellType[][] contradictionPatterns){
-        super(ruleName, description, imageName);
+        super(ruleID, ruleName, description, imageName);
         this.operationSymbol = operationSymbol;
         this.contradictionPatterns = contradictionPatterns;
     }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/shorttruthtable_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/rules/shorttruthtable_reference_sheet.txt
@@ -1,0 +1,24 @@
+STTT-BASC-0001 : BasicRuleAtomic
+STTT-BASC-0002 : BasicRuleAndElimination
+STTT-BASC-0003 : BasicRuleBiconditionalElimination
+STTT-BASC-0004 : BasicRuleConditionalElimination
+STTT-BASC-0005 : BasicRuleNotElimination
+STTT-BASC-0006 : BasicRuleOrElimination
+STTT-BASC-0007 : BasicRuleAndIntroduction
+STTT-BASC-0008 : BasicRuleBiconditionalIntroduction
+STTT-BASC-0009 : BasicRuleConditionalIntroduction
+STTT-BASC-0010 : BasicRuleNotIntroduction
+STTT-BASC-0011 : BasicRuleOrIntroduction
+
+STTT-CASE-0001 : CaseRuleAnd
+STTT-CASE-0002 : CaseRuleAtomic
+STTT-CASE-0003 : CaseRuleBiconditional
+STTT-CASE-0004 : CaseRuleConditional
+STTT-CASE-0005 : CaseRuleOr
+
+STTT-CONT-0001 : ContradictionRuleAnd
+STTT-CONT-0002 : ContradictionRuleAtomic
+STTT-CONT-0003 : ContradictionRuleBiconditional
+STTT-CONT-0004 : ContradictionRuleConditional
+STTT-CONT-0005 : ContradictionRuleNot
+STTT-CONT-0006 : ContradictionRuleOr

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/DuplicateNumberContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/DuplicateNumberContradictionRule.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class DuplicateNumberContradictionRule extends ContradictionRule {
 
     public DuplicateNumberContradictionRule() {
-        super("Duplicate Number",
+        super("SKYS-CONT-0001", "Duplicate Number",
                 "Skyscrapers of same height cannot be placed in the same row or column.",
                 "edu/rpi/legup/images/skyscrapers/DuplicateNumber.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/ExceedingVisibilityContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/ExceedingVisibilityContradictionRule.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class ExceedingVisibilityContradictionRule extends ContradictionRule {
 
     public ExceedingVisibilityContradictionRule() {
-        super("Exceeding Visibility",
+        super("SKYS-CONT-0002", "Exceeding Visibility",
                 "More skyscrapers are visible than there should be.",
                 "edu/rpi/legup/images/skyscrapers/ExceedingVisibility.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/FixedMaxBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/FixedMaxBasicRule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class FixedMaxBasicRule extends BasicRule {
 
     public FixedMaxBasicRule() {
-        super("Fixed Max",
+        super("SKYS-BASC-0001","Fixed Max",
                 "If the sum of two opposing edges is n+1, the maximum number appears at a position k spaces away from the edge, where k is the number at that edge.",
                 "edu/rpi/legup/images/skyscrapers/FixedMax.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/InsufficientVisibilityContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/InsufficientVisibilityContradictionRule.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class InsufficientVisibilityContradictionRule extends ContradictionRule {
 
     public InsufficientVisibilityContradictionRule() {
-        super("Insufficient Visibility",
+        super("SKYS-CONT-0003", "Insufficient Visibility",
                 "Less skyscrapers are visible than there should be.",
                 "edu/rpi/legup/images/skyscrapers/InsufficientVisibility.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/LastCellBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/LastCellBasicRule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class LastCellBasicRule extends BasicRule {
 
     public LastCellBasicRule() {
-        super("Last Cell",
+        super("SKYS-BASC-0002", "Last Cell",
                 "A certain number must go in a certain cell, because that cell is the last place that number can appear in that row/column.",
                 "edu/rpi/legup/images/skyscrapers/LastCell.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/LastNumberBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/LastNumberBasicRule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class LastNumberBasicRule extends BasicRule {
 
     public LastNumberBasicRule() {
-        super("Last Number",
+        super("SKYS-BASC-0003", "Last Number",
                 "A certain cell must contain a certain number since that number is the only one that can possibly appear in that cell.",
                 "edu/rpi/legup/images/skyscrapers/LastNumber.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/NEdgeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/NEdgeBasicRule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class NEdgeBasicRule extends BasicRule {
 
     public NEdgeBasicRule() {
-        super("N Edge",
+        super("SKYS-BASC-0004", "N Edge",
                 "If the maximum number appears on an edge, the row or column��s numbers appear in ascending order, starting at that edge.",
                 "edu/rpi/legup/images/skyscrapers/NEdge.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/OneEdgeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/OneEdgeBasicRule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class OneEdgeBasicRule extends BasicRule {
 
     public OneEdgeBasicRule() {
-        super("One Edge",
+        super("SKYS-BASC-0005", "One Edge",
                 "If you have a 1 on an edge, put n in the adjacent square.",
                 "edu/rpi/legup/images/skyscrapers/OneEdge.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/PossibleContentsCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/PossibleContentsCaseRule.java
@@ -17,7 +17,7 @@ import java.util.*;
 public class PossibleContentsCaseRule extends CaseRule {
 
     public PossibleContentsCaseRule() {
-        super("Possible Contents",
+        super("SKYS-CASE-0001", "Possible Contents",
                 "Each blank cell is could have height of 1 to n.",
                 "edu/rpi/legup/images/skyscrapers/PossibleContents.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/UnresolvedCellContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/UnresolvedCellContradictionRule.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class UnresolvedCellContradictionRule extends ContradictionRule {
 
     public UnresolvedCellContradictionRule() {
-        super("Unresolved Cell",
+        super("SKYS-CONT-0004", "Unresolved Cell",
                 "Elimination leaves no possible number for a cell.",
                 "edu/rpi/legup/images/skyscrapers/UnresolvedCell.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/skyscrapers_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/skyscrapers_reference_sheet.txt
@@ -1,0 +1,12 @@
+SKYS-BASC-0001 : FixedMaxBasicRule
+SKYS-BASC-0002 : LastCellBasicRule
+SKYS-BASC-0003 : LastNUmberBasicRule
+SKYS-BASC-0004 : NEdgeBasicRule
+SKYS-BASC-0005 : OneEdgeBasicRule
+
+SKYS-CONT-0001 : DuplicateNumbersContradictionRule
+SKYS-CONT-0002 : ExceedingVisibilityContradictionRule
+SKYS-CONT-0003 : InsufficientVisibilityContradictionRule
+SKYS-CONT-0004 : UnresolvedCellContradictionRule
+
+SKYS-CASE-0001 : PossibleContentsCaseRule

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/AdvancedDeductionBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/AdvancedDeductionBasicRule.java
@@ -11,7 +11,7 @@ import edu.rpi.legup.puzzle.sudoku.SudokuCell;
 public class AdvancedDeductionBasicRule extends BasicRule {
 
     public AdvancedDeductionBasicRule() {
-        super("Advanced Deduction",
+        super("SUDO-BASC-0001", "Advanced Deduction",
                 "Use of group logic deduces more answers by means of forced by Location and forced by Deduction",
                 "edu/rpi/legup/images/sudoku/AdvancedDeduction.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/LastCellForNumberBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/LastCellForNumberBasicRule.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public class LastCellForNumberBasicRule extends BasicRule {
     public LastCellForNumberBasicRule() {
-        super("Last Cell for Number",
+        super("SUDO-BASC-0002", "Last Cell for Number",
                 "This is the only cell open in its group for some number.",
                 "edu/rpi/legup/images/sudoku/forcedByElimination.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/LastNumberForCellBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/LastNumberForCellBasicRule.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 public class LastNumberForCellBasicRule extends BasicRule {
 
     public LastNumberForCellBasicRule() {
-        super("Last Number for Cell",
+        super("SUDO-BASC-0003", "Last Number for Cell",
                 "This is the only number left that can fit in the cell of a group.",
                 "edu/rpi/legup/images/sudoku/forcedByDeduction.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/NoSolutionContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/NoSolutionContradictionRule.java
@@ -12,7 +12,7 @@ import java.util.Set;
 public class NoSolutionContradictionRule extends ContradictionRule {
 
     public NoSolutionContradictionRule() {
-        super("No Solution for Cell",
+        super("SUDO-CONT-0001", "No Solution for Cell",
                 "Process of elimination yields no valid numbers for an empty cell.",
                 "edu/rpi/legup/images/sudoku/NoSolution.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/PossibleCellCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/PossibleCellCaseRule.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 public class PossibleCellCaseRule extends CaseRule {
     public PossibleCellCaseRule() {
-        super("Possible Cells for Number",
+        super("SUDO-CASE-0001", "Possible Cells for Number",
                 "A number has a limited set of cells in which it can be placed.",
                 "edu/rpi/legup/images/sudoku/possible_cells_number.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/PossibleNumberCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/PossibleNumberCaseRule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class PossibleNumberCaseRule extends CaseRule {
 
     public PossibleNumberCaseRule() {
-        super("Possible Numbers for Cell",
+        super("SUDO-CASE-0002", "Possible Numbers for Cell",
                 "An empty cell has a limited set of possible numbers that can fill it.",
                 "edu/rpi/legup/images/sudoku/PossibleValues.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/RepeatedNumberContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/RepeatedNumberContradictionRule.java
@@ -12,7 +12,7 @@ import java.util.Set;
 public class RepeatedNumberContradictionRule extends ContradictionRule {
 
     public RepeatedNumberContradictionRule() {
-        super("Repeated Numbers",
+        super("SUDO-CONT-0002", "Repeated Numbers",
                 "Two identical numbers are placed in the same group.",
                 "edu/rpi/legup/images/sudoku/RepeatedNumber.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/sudoku_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/rules/sudoku_reference_sheet.txt
@@ -1,0 +1,9 @@
+SUDO-BASC-0001 : AdvancedDeductionBasicRule
+SUDO-BASC-0002 : LastCellForNumberBasicRule
+SUDO-BASC-0003 : LastNumberForCellBasicRule
+
+SUDO-CONT-0001 : NoSolutionContradictionRule
+SUDO-CONT-0002 : RepeatedNumberContradictionRule
+
+SUDO-CASE-0001 : PossibleCellCaseRule
+SUDO-CASE-0002 : PossibleNumberCaseRule

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/EmptyFieldBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/EmptyFieldBasicRule.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class EmptyFieldBasicRule extends BasicRule {
     public EmptyFieldBasicRule() {
-        super("Empty Field",
+        super("TREE-BASC-0001", "Empty Field",
                 "Blank cells not adjacent to an unlinked tree are grass.",
                 "edu/rpi/legup/images/treetent/noTreesAround.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/FillinRowCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/FillinRowCaseRule.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 public class FillinRowCaseRule extends CaseRule {
 
     public FillinRowCaseRule() {
-        super("Fill In row",
+        super("TREE-CASE-0001", "Fill In row",
                 "A row must have the number of tents of its clue.",
                 "edu/rpi/legup/images/treetent/case_rowcount.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/FinishWithGrassBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/FinishWithGrassBasicRule.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class FinishWithGrassBasicRule extends BasicRule {
 
     public FinishWithGrassBasicRule() {
-        super("Finish with Grass",
+        super("TREE-BASC-0002", "Finish with Grass",
                 "Grass can be added to finish a row or column that has reached its tent limit.",
                 "edu/rpi/legup/images/treetent/finishGrass.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/FinishWithTentsBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/FinishWithTentsBasicRule.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class FinishWithTentsBasicRule extends BasicRule {
 
     public FinishWithTentsBasicRule() {
-        super("Finish with Tents",
+        super("TREE-BASC-0003", "Finish with Tents",
                 "Tents can be added to finish a row or column that has one open spot per required tent.",
                 "edu/rpi/legup/images/treetent/finishTent.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/LastCampingSpotBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/LastCampingSpotBasicRule.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class LastCampingSpotBasicRule extends BasicRule {
 
     public LastCampingSpotBasicRule() {
-        super("Last Camping Spot",
+        super("TREE-BASC-0004", "Last Camping Spot",
                 "If an unlinked tree is adjacent to only one blank cell and not adjacent to any unlinked tents, the blank cell must be a tent.",
                 "edu/rpi/legup/images/treetent/oneTentPosition.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/LinkTentCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/LinkTentCaseRule.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 public class LinkTentCaseRule extends CaseRule {
 
     public LinkTentCaseRule() {
-        super("Links from tent",
+        super("TREE-CASE-0002", "Links from tent",
                 "A tent must link to exactly one adjacent tree.",
                 "edu/rpi/legup/images/treetent/caseLinkTent.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/LinkTreeCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/LinkTreeCaseRule.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class LinkTreeCaseRule extends CaseRule {
 
     public LinkTreeCaseRule() {
-        super("Links from tree",
+        super("TREE-CASE-0003", "Links from tree",
                 "A tree must link to exactly one adjacent tent.",
                 "edu/rpi/legup/images/treetent/caseLinkTree.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/NoTentForTreeContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/NoTentForTreeContradictionRule.java
@@ -10,7 +10,7 @@ import edu.rpi.legup.puzzle.treetent.TreeTentType;
 public class NoTentForTreeContradictionRule extends ContradictionRule {
 
     public NoTentForTreeContradictionRule() {
-        super("No Tent For Tree",
+        super("TREE-CONT-0001", "No Tent For Tree",
                 "Each tree must link to a tent.",
                 "edu/rpi/legup/images/treetent/contra_NoTentForTree.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/NoTreeForTentContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/NoTreeForTentContradictionRule.java
@@ -10,7 +10,7 @@ import edu.rpi.legup.puzzle.treetent.TreeTentType;
 public class NoTreeForTentContradictionRule extends ContradictionRule {
 
     public NoTreeForTentContradictionRule() {
-        super("No Tree For Tent",
+        super("TREE-CONT-0002", "No Tree For Tent",
                 "Each tent must link to a tree.",
                 "edu/rpi/legup/images/treetent/contra_NoTreeForTent.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/SurroundTentWithGrassBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/SurroundTentWithGrassBasicRule.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class SurroundTentWithGrassBasicRule extends BasicRule {
 
     public SurroundTentWithGrassBasicRule() {
-        super("Surround Tent with Grass",
+        super("TREE-BASC-0005", "Surround Tent with Grass",
                 "Blank cells adjacent or diagonal to a tent are grass.",
                 "edu/rpi/legup/images/treetent/aroundTent.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TentForTreeBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TentForTreeBasicRule.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class TentForTreeBasicRule extends BasicRule {
 
     public TentForTreeBasicRule() {
-        super("Tent for Tree",
+        super("TREE-BASC-0006", "Tent for Tree",
                 "If only one unlinked tent and no blank cells are adjacent to an unlinked tree, the unlinked tree must link to the unlinked tent.",
                 "edu/rpi/legup/images/treetent/NewTreeLink.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TentOrGrassCaseRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TentOrGrassCaseRule.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class TentOrGrassCaseRule extends CaseRule {
 
     public TentOrGrassCaseRule() {
-        super("Tree or Grass",
+        super("TREE-CASE-0004", "Tree or Grass",
                 "Each blank cell is either a tent or grass.",
                 "edu/rpi/legup/images/treetent/caseTentOrGrass.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TooFewTentsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TooFewTentsContradictionRule.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public class TooFewTentsContradictionRule extends ContradictionRule {
 
     public TooFewTentsContradictionRule() {
-        super("Too Few Tents",
+        super("TREE-CONT-0003", "Too Few Tents",
                 "Rows and columns cannot have fewer tents than their clue.",
                 "edu/rpi/legup/images/treetent/too_few_tents.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TooManyTentsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TooManyTentsContradictionRule.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public class TooManyTentsContradictionRule extends ContradictionRule {
 
     public TooManyTentsContradictionRule() {
-        super("Too Many Tents",
+        super("TREE-CONT-0004", "Too Many Tents",
                 "Rows and columns cannot have more tents than their clue.",
                 "edu/rpi/legup/images/treetent/too_many_tents.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TouchingTentsContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TouchingTentsContradictionRule.java
@@ -10,7 +10,7 @@ import edu.rpi.legup.puzzle.treetent.TreeTentType;
 public class TouchingTentsContradictionRule extends ContradictionRule {
 
     public TouchingTentsContradictionRule() {
-        super("Touching Tents",
+        super("TREE-CONT-0005", "Touching Tents",
                 "Tents cannot touch other tents.",
                 "edu/rpi/legup/images/treetent/contra_adjacentTents.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TreeForTentBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/TreeForTentBasicRule.java
@@ -8,7 +8,7 @@ import edu.rpi.legup.model.tree.TreeTransition;
 
 public class TreeForTentBasicRule extends BasicRule {
     public TreeForTentBasicRule() {
-        super("Tree for Tent",
+        super("TREE-BASC-0007", "Tree for Tent",
                 "If only one unlinked tree is adjacent to an unlinked tent, the unlinked tent must link to the unlinked tree.",
                 "edu/rpi/legup/images/treetent/NewTentLink.png");
     }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/rules/treetent_reference_sheet.txt
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/rules/treetent_reference_sheet.txt
@@ -1,0 +1,18 @@
+TREE-BASC-0001 : EmptyFieldBasicRule
+TREE-BASC-0002 : FinishWithGrassBasicRule
+TREE-BASC-0003 : FinishWithTentsBasicRule
+TREE-BASC-0004 : LastCampingSpotBasicRule
+TREE-BASC-0005 : SurroundTentWithGrassBasicRule
+TREE-BASC-0006 : TentForTreeBasicRule
+TREE-BASC-0007 : TreeForTentBasicRule
+
+TREE-CONT-0001 : NoTentForTreeContradictionRule
+TREE-CONT-0002 : NoTreeForTentContradictionRule
+TREE-CONT-0003 : TooFewTentsContradictionRule
+TREE-CONT-0004 : TooManyTentsContradictionRule
+TREE-CONT-0005 : TouchingTentsContradictionRule
+
+TREE-CASE-0001 : FillInRowCaseRule
+TREE-CASE-0002 : LinkTentCaseRule
+TREE-CASE-0003 : LinkTreeCaseRule
+TREE-CASE-0004 : TentOrGrassCaseRule


### PR DESCRIPTION
Gave each rule a unique ID. This means now that identification of rules no longer relies on the name of the rule, and so rules can be freely renamed. Note that this update will also break backwards compatibility with any puzzle files that contained proofs, but not raw puzzle files.

Note that `dev_uid` is resolves all the conflicts between `dev` and `uid`.