### PR TITLE
Fix Previous State Placement

### DIFF
--- a/src/main/java/edu/rpi/legup/model/gameboard/Board.java
+++ b/src/main/java/edu/rpi/legup/model/gameboard/Board.java
@@ -146,7 +146,7 @@ public abstract class Board {
      */
     @SuppressWarnings("unchecked")
     public void notifyChange(PuzzleElement puzzleElement) {
-        puzzleElements.get(puzzleElement.getIndex()).setData(puzzleElement.getData());
+        puzzleElements.set(puzzleElement.getIndex(), puzzleElement);
     }
 
     /**


### PR DESCRIPTION
This fixes the issue mentioned below where changing the previous state can prevent you from modifying the board. Only part of the cell was being changed so now the entire cell gets changed.

Fixes #97