### PR TITLE
TreePanel.java line 57

### DIFF
--- a/src/main/java/edu/rpi/legup/ui/treeview/TreePanel.java
+++ b/src/main/java/edu/rpi/legup/ui/treeview/TreePanel.java
@@ -54,7 +54,7 @@ public class TreePanel extends JPanel {
         status.setPreferredSize(new Dimension(150, 15));
         dynamicTreeView.getZoomWrapper().add(status, BorderLayout.CENTER);
 
-        TitledBorder title = BorderFactory.createTitledBorder("TreePanel");
+        TitledBorder title = BorderFactory.createTitledBorder("Proof Tree");
         title.setTitleJustification(TitledBorder.CENTER);
         main.setBorder(title);
 


### PR DESCRIPTION
Issue 104: Change "TreePanel" text in the tree panel to "Proof Tree". I changed the code located in TreePanel.java. It now shows "Proof Tree." 

![image](https://user-images.githubusercontent.com/106495933/172463453-50221ef7-083f-44a0-8ac5-456a7da4be68.png)
