### PR TITLE
Fixed visual bug when running jar file outside IntelliJ

### DIFF
--- a/src/main/java/edu/rpi/legup/model/elements/Element.java
+++ b/src/main/java/edu/rpi/legup/model/elements/Element.java
@@ -30,7 +30,7 @@ public abstract class Element {
 
     private void loadImage() {
         if (imageName != null) {
-            this.image = new ImageIcon(ClassLoader.getSystemResource(imageName));
+            this.image = new ImageIcon(ClassLoader.getSystemClassLoader().getResource(imageName));
             //Resize images to be 100px wide
             Image image = this.image.getImage();
             if (this.image.getIconWidth() < 120) return;

--- a/src/main/java/edu/rpi/legup/model/rules/Rule.java
+++ b/src/main/java/edu/rpi/legup/model/rules/Rule.java
@@ -84,7 +84,7 @@ public abstract class Rule {
      */
     private void loadImage() {
         if (imageName != null) {
-            this.image = new ImageIcon(ClassLoader.getSystemResource(imageName));
+            this.image = new ImageIcon(ClassLoader.getSystemClassLoader().getResource(imageName));
             //Resize images to be 100px wide
             Image image = this.image.getImage();
             if (this.image.getIconWidth() < 120) return;


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixed a bug where if you ran the jar file outside of your IntelliJ environment, the element icons would not show up

<!-- If your pull request is not related to a particular issue, delete the statement below. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
I ran the jar file outside of my IntelliJ environment and the icons showed up

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
