### PR TITLE
Puzzle editor selection cosmetic changes

### DIFF
--- a/src/main/java/edu/rpi/legup/app/Config.java
+++ b/src/main/java/edu/rpi/legup/app/Config.java
@@ -38,13 +38,18 @@ public class Config {
      *
      * @return Vector of Puzzle names which are Strings
      */
-    public List<String> getPuzzleNames() {
-        return new ArrayList<>(puzzles.keySet());
+    public List<String> getPuzzleClassNames() {
+        return new LinkedList<>(puzzles.keySet());
     }
 
+    /**
+     * Returns a list of the names of the puzzles which can have puzzles created and edited
+     * within the proof editor.
+     * @return the aforementioned list of Strings
+     */
     public List<String> getFileCreationEnabledPuzzles() {
         LinkedList<String> puzzles = new LinkedList<String>();
-        for (String puzzle : this.puzzles.keySet()) {
+        for (String puzzle : this.getPuzzleClassNames()) {
             if (!this.fileCreationDisabledStatuses.get(puzzle)) {
                 puzzles.add(puzzle);
             }
@@ -52,6 +57,46 @@ public class Config {
         return puzzles;
     }
 
+    /**
+     * Converts the class name of the puzzles to their display names. Some examples of the conversion:
+     * convertClassNameToDisplayName("TreeTent") will return "Tree Tent"
+     * convertClassNameToDisplayName("Nurikabe") will return "Nurikabe"
+     *
+     * @param className the name of the class
+     * @return
+     */
+    public static String convertClassNameToDisplayName(String className) {
+        String displayName = "";
+        for (int i = 0; i < className.length(); i++)
+        {
+            if (Character.isUpperCase(className.charAt(i)) && i != 0)
+                displayName += " ";
+            displayName += className.charAt(i);
+        }
+        return displayName;
+    }
+
+    public static String convertDisplayNameToClassName(String displayName) {
+        String className = "";
+        for (int i = 0; i < displayName.length(); i++)
+            if (displayName.charAt(i) == ' ')
+                className += displayName;
+        return className;
+    }
+
+    public List<String> getPuzzleNames() {
+        List<String> names = new LinkedList<String>();
+        for (String puzzle : this.getPuzzleClassNames())
+            names.add(Config.convertClassNameToDisplayName(puzzle));
+        return names;
+    }
+
+    public List<String> getFileCreationEnabledPuzzleNames() {
+        List<String> names = new LinkedList<String>();
+        for (String puzzle : this.getFileCreationEnabledPuzzles())
+            names.add(Config.convertClassNameToDisplayName(puzzle));
+        return names;
+    }
 
     /**
      * Gets a {@link edu.rpi.legup.model.Puzzle} class for a puzzle name

--- a/src/main/java/edu/rpi/legup/ui/CreatePuzzleDialog.java
+++ b/src/main/java/edu/rpi/legup/ui/CreatePuzzleDialog.java
@@ -1,5 +1,6 @@
 package edu.rpi.legup.ui;
 
+import edu.rpi.legup.app.Config;
 import edu.rpi.legup.app.GameBoardFacade;
 import edu.rpi.legup.controller.CursorController;
 
@@ -105,12 +106,12 @@ public class CreatePuzzleDialog extends JDialog {
     public void initPuzzles() {
         this.games = GameBoardFacade.getInstance().getConfig().getFileCreationEnabledPuzzles().toArray(new String[0]);
         Arrays.sort(this.games);
-        gameBox = new JComboBox(games);
+        gameBox = new JComboBox(GameBoardFacade.getInstance().getConfig().getFileCreationEnabledPuzzleNames().toArray(new String[0]));
     }
 
     public void actionPerformed(ActionEvent e) {
         if (e.getSource() == ok) {
-            String game = (String) gameBox.getSelectedItem();
+            String game = Config.convertDisplayNameToClassName((String) gameBox.getSelectedItem());
             try {
                 this.homePanel.openEditorWithNewPuzzle(game, Integer.valueOf(this.rows.getText()), Integer.valueOf(this.columns.getText()));
                 setVisible(false);
@@ -124,10 +125,5 @@ public class CreatePuzzleDialog extends JDialog {
                 setVisible(false);
             }
         }
-    }
-
-    private boolean isValidDimensions() {
-        // Needs to be implemented
-        return false;
     }
 }

--- a/src/main/java/edu/rpi/legup/ui/PickGameDialog.java
+++ b/src/main/java/edu/rpi/legup/ui/PickGameDialog.java
@@ -115,7 +115,7 @@ public class PickGameDialog extends JDialog implements ActionListener {
     }
 
     public void initPuzzles() {
-        Object[] o = GameBoardFacade.getInstance().getConfig().getPuzzleNames().toArray();
+        Object[] o = GameBoardFacade.getInstance().getConfig().getPuzzleClassNames().toArray();
 
         games = new String[o.length];
 

--- a/src/main/resources/edu/rpi/legup/legup/config
+++ b/src/main/resources/edu/rpi/legup/legup/config
@@ -15,7 +15,7 @@
         <puzzle name="LightUp"
             qualifiedClassName="edu.rpi.legup.puzzle.lightup.LightUp"
             fileType=".xml"
-            fileCreationDisabled="false"/>
+            fileCreationDisabled="true"/>
         <puzzle name="Masyu"
             qualifiedClassName="edu.rpi.legup.puzzle.masyu.Masyu"
             fileType=".xml"
@@ -30,7 +30,7 @@
             fileCreationDisabled="true"/>
         <puzzle name="Sudoku" qualifiedClassName="edu.rpi.legup.puzzle.sudoku.Sudoku"
             fileType=".xml"
-            fileCreationDisabled="false"/>
+            fileCreationDisabled="true"/>
         <puzzle name="TreeTent"
             qualifiedClassName="edu.rpi.legup.puzzle.treetent.TreeTent"
             fileType=".xml"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Spaces are now properly displayed in the puzzle editor selection menu
- Adjusted config file so that only Nurikabe and Tree Tent puzzles can be created

<!-- If your pull request is not related to a particular issue, delete the statement below. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
