### PR TITLE
Made Treetent Puzzles editable and saveable

### DIFF
--- a/src/main/java/edu/rpi/legup/app/Config.java
+++ b/src/main/java/edu/rpi/legup/app/Config.java
@@ -79,8 +79,8 @@ public class Config {
     public static String convertDisplayNameToClassName(String displayName) {
         String className = "";
         for (int i = 0; i < displayName.length(); i++)
-            if (displayName.charAt(i) == ' ')
-                className += displayName;
+            if (displayName.charAt(i) != ' ')
+                className += displayName.charAt(i);
         return className;
     }
 

--- a/src/main/java/edu/rpi/legup/controller/ElementController.java
+++ b/src/main/java/edu/rpi/legup/controller/ElementController.java
@@ -1,5 +1,6 @@
 package edu.rpi.legup.controller;
 
+import edu.rpi.legup.puzzle.treetent.TreeTentBoard;
 import edu.rpi.legup.ui.ScrollView;
 import edu.rpi.legup.app.GameBoardFacade;
 import edu.rpi.legup.app.LegupPreferences;
@@ -129,17 +130,20 @@ public class ElementController implements MouseListener, MouseMotionListener, Ac
                 }
             }
         }
-        if (selectedElement != null) {
+//        if (selectedElement != null) {
             GridBoard b = (GridBoard) this.boardView.getBoard();
             Point point = e.getPoint();
             Point scaledPoint = new Point((int) Math.floor(point.x / (30*this.boardView.getScale())), (int) Math.floor(point.y / (30*this.boardView.getScale())));
+            if(this.boardView.getBoard() instanceof TreeTentBoard) {
+                scaledPoint.setLocation(scaledPoint.getX() - 1, scaledPoint.getY() - 1);
+            }
             System.out.printf("selected Element is NOT null, attempting to change board at (%d, %d)\n", scaledPoint.x, scaledPoint.y);
-            System.out.println("Before: " + b.getCell(scaledPoint.x, scaledPoint.y).getData());
+//            System.out.println("Before: " + b.getCell(scaledPoint.x, scaledPoint.y).getData());
             b.setCell(scaledPoint.x, scaledPoint.y, this.selectedElement, e);
-            System.out.println("After: " + b.getCell(scaledPoint.x, scaledPoint.y).getData());
-        } else {
-            System.out.println("selected Element is null!");
-        }
+//            System.out.println("After: " + b.getCell(scaledPoint.x, scaledPoint.y).getData());
+//        } else {
+//            System.out.println("selected Element is null!");
+//        }
         boardView.repaint();
     }
 

--- a/src/main/java/edu/rpi/legup/model/gameboard/GridBoard.java
+++ b/src/main/java/edu/rpi/legup/model/gameboard/GridBoard.java
@@ -2,6 +2,8 @@ package edu.rpi.legup.model.gameboard;
 
 import edu.rpi.legup.model.elements.Element;
 import edu.rpi.legup.puzzle.nurikabe.NurikabeCell;
+import edu.rpi.legup.puzzle.treetent.TreeTentBoard;
+import edu.rpi.legup.puzzle.treetent.TreeTentClue;
 
 import java.awt.*;
 import java.awt.event.MouseEvent;
@@ -66,12 +68,27 @@ public class GridBoard extends Board {
     }
 
     public void setCell(int x, int y, Element e, MouseEvent m) {
-        if (y * dimension.width + x >= puzzleElements.size() || x >= dimension.width ||
+        if(this instanceof TreeTentBoard && ((y == dimension.height && 0 <= x && x < dimension.width) || (x == dimension.width && 0 <= y && y < dimension.height))) {
+            TreeTentBoard treeTentBoard = ((TreeTentBoard) this);
+            TreeTentClue clue = treeTentBoard.getClue(x, y);
+            if(y == dimension.height && clue.getData() < dimension.width) {
+                clue.setData(clue.getData() + 1);
+            }
+            else if(x == dimension.width && clue.getData() < dimension.height) {
+                clue.setData(clue.getData() + 1);
+            }
+            else {
+                clue.setData(0);
+            }
+        }
+        else if (e != null && y * dimension.width + x >= puzzleElements.size() || x >= dimension.width ||
                 y >= dimension.height || x < 0 || y < 0) {
             return;
         }
-        ((NurikabeCell) puzzleElements.get(y * dimension.width + x)).setType(e, m);
-        puzzleElements.set(y * dimension.width + x, puzzleElements.get(y * dimension.width + x));
+        else if(e != null){
+            puzzleElements.get(y * dimension.width + x).setType(e, m);
+        }
+//        puzzleElements.set(y * dimension.width + x, puzzleElements.get(y * dimension.width + x));
     }
 
     /**

--- a/src/main/java/edu/rpi/legup/model/gameboard/PuzzleElement.java
+++ b/src/main/java/edu/rpi/legup/model/gameboard/PuzzleElement.java
@@ -1,5 +1,9 @@
 package edu.rpi.legup.model.gameboard;
 
+import edu.rpi.legup.model.elements.Element;
+
+import java.awt.event.MouseEvent;
+
 public abstract class PuzzleElement<T> {
     protected int index;
     protected T data;
@@ -47,6 +51,8 @@ public abstract class PuzzleElement<T> {
     public void setData(T data) {
         this.data = data;
     }
+
+    public void setType(Element e, MouseEvent m) { return; }
 
     /**
      * Gets whether this puzzle element is modifiable.

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeCell.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeCell.java
@@ -44,6 +44,7 @@ public class NurikabeCell extends GridCell<Integer> {
      *
      * @param e element to set the type of this nurikabe cell to
      */
+    @Override
     public void setType(Element e, MouseEvent m) {
         if (e.getElementName().equals("Black Tile")) {
             this.data = -1;

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
@@ -23,6 +23,7 @@ public class TreeTent extends Puzzle {
     public void initializeView() {
         TreeTentBoard board = (TreeTentBoard) currentBoard;
         boardView = new TreeTentView((TreeTentBoard) currentBoard);
+        boardView.setBoard(board);
     }
 
     /**

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentBoard.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentBoard.java
@@ -72,6 +72,16 @@ public class TreeTentBoard extends GridBoard {
         }
     }
 
+    public TreeTentClue getClue(int x, int y) {
+        if(x == getWidth() && 0 <= y && y < getHeight()) {
+            return rowClues.get(y);
+        }
+        else if(y == getHeight() && 0 <= x && x < getWidth()) {
+            return colClues.get(x);
+        }
+        return null;
+    }
+
     /**
      * Called when a {@link PuzzleElement} has been added and passes in the equivalent puzzle element with the data.
      *

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentCell.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentCell.java
@@ -1,8 +1,10 @@
 package edu.rpi.legup.puzzle.treetent;
 
+import edu.rpi.legup.model.elements.Element;
 import edu.rpi.legup.model.gameboard.GridCell;
 
 import java.awt.*;
+import java.awt.event.MouseEvent;
 
 public class TreeTentCell extends GridCell<Integer> {
 
@@ -22,6 +24,22 @@ public class TreeTentCell extends GridCell<Integer> {
                 return TreeTentType.TENT;
             default:
                 return null;
+        }
+    }
+
+    @Override
+    public void setType(Element e, MouseEvent m) {
+        if(e.getElementName().equals("Unknown Tile")) {
+            this.data = 0;
+        }
+        else if(e.getElementName().equals("Tree Tile")) {
+            this.data = 1;
+        }
+        else if(e.getElementName().equals("Grass Tile")) {
+            this.data = 2;
+        }
+        else if(e.getElementName().equals("Tent Tile")) {
+            this.data = 3;
         }
     }
 

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentController.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentController.java
@@ -29,83 +29,83 @@ public class TreeTentController extends ElementController {
         this.lastCellPressed = null;
     }
 
-    @Override
-    public void mousePressed(MouseEvent e) {
-        if (e.getButton() != MouseEvent.BUTTON2) {
-            BoardView boardView = getInstance().getLegupUI().getBoardView();
-            dragStart = boardView.getElement(e.getPoint());
-            lastCellPressed = boardView.getElement(e.getPoint());
-        }
-    }
+//    @Override
+//    public void mousePressed(MouseEvent e) {
+//        if (e.getButton() != MouseEvent.BUTTON2) {
+//            BoardView boardView = getInstance().getLegupUI().getBoardView();
+//            dragStart = boardView.getElement(e.getPoint());
+//            lastCellPressed = boardView.getElement(e.getPoint());
+//        }
+//    }
 
-    @Override
-    public void mouseReleased(MouseEvent e) {
-        if (e.getButton() != MouseEvent.BUTTON2) {
-            TreePanel treePanel = GameBoardFacade.getInstance().getLegupUI().getTreePanel();
-            TreeView treeView = GameBoardFacade.getInstance().getLegupUI().getTreePanel().getTreeView();
-            BoardView boardView = getInstance().getLegupUI().getBoardView();
-            lastCellPressed = boardView.getElement(e.getPoint());
-            Board board = boardView.getBoard();
-            TreeViewSelection selection = treeView.getSelection();
-
-            if (dragStart != null) {
-                if (board instanceof CaseBoard) {
-                    CaseBoard caseBoard = (CaseBoard) board;
-                    AutoCaseRuleCommand autoCaseRuleCommand = new AutoCaseRuleCommand(dragStart, selection, caseBoard.getCaseRule(), caseBoard, e);
-                    if (autoCaseRuleCommand.canExecute()) {
-                        autoCaseRuleCommand.execute();
-                        getInstance().getHistory().pushChange(autoCaseRuleCommand);
-                        treePanel.updateError("");
-                    }
-                    else {
-                        treePanel.updateError(autoCaseRuleCommand.getError());
-                    }
-                }
-                else {
-                    if (dragStart == lastCellPressed) {
-                        if (dragStart.getPuzzleElement().getIndex() >= 0) {
-                            ICommand edit = new EditDataCommand(lastCellPressed, selection, e);
-                            if (edit.canExecute()) {
-                                edit.execute();
-                                getInstance().getHistory().pushChange(edit);
-                                treePanel.updateError("");
-                            }
-                            else {
-                                treePanel.updateError(edit.getError());
-                            }
-                        }
-                        else {
-                            ClueCommand edit = new ClueCommand(selection, (TreeTentClueView) dragStart);
-                            if (edit.canExecute()) {
-                                edit.execute();
-                                getInstance().getHistory().pushChange(edit);
-                                treePanel.updateError("");
-                            }
-                            else {
-                                treePanel.updateError(edit.getError());
-                            }
-                        }
-                    }
-                    else {
-                        if (lastCellPressed != null) {
-                            if (dragStart instanceof TreeTentElementView) {
-                                ICommand editLine = new EditLineCommand(selection, (TreeTentElementView) dragStart, lastCellPressed);
-                                if (editLine.canExecute()) {
-                                    editLine.execute();
-                                    getInstance().getHistory().pushChange(editLine);
-                                }
-                                else {
-                                    treePanel.updateError(editLine.getError());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            dragStart = null;
-            lastCellPressed = null;
-        }
-    }
+//    @Override
+//    public void mouseReleased(MouseEvent e) {
+//        if (GameBoardFacade.getInstance().getLegupUI().getTreePanel() != null && e.getButton() != MouseEvent.BUTTON2) {
+//            TreePanel treePanel = GameBoardFacade.getInstance().getLegupUI().getTreePanel();
+//            TreeView treeView = GameBoardFacade.getInstance().getLegupUI().getTreePanel().getTreeView();
+//            BoardView boardView = getInstance().getLegupUI().getBoardView();
+//            lastCellPressed = boardView.getElement(e.getPoint());
+//            Board board = boardView.getBoard();
+//            TreeViewSelection selection = treeView.getSelection();
+//
+//            if (dragStart != null) {
+//                if (board instanceof CaseBoard) {
+//                    CaseBoard caseBoard = (CaseBoard) board;
+//                    AutoCaseRuleCommand autoCaseRuleCommand = new AutoCaseRuleCommand(dragStart, selection, caseBoard.getCaseRule(), caseBoard, e);
+//                    if (autoCaseRuleCommand.canExecute()) {
+//                        autoCaseRuleCommand.execute();
+//                        getInstance().getHistory().pushChange(autoCaseRuleCommand);
+//                        treePanel.updateError("");
+//                    }
+//                    else {
+//                        treePanel.updateError(autoCaseRuleCommand.getError());
+//                    }
+//                }
+//                else {
+//                    if (dragStart == lastCellPressed) {
+//                        if (dragStart.getPuzzleElement().getIndex() >= 0) {
+//                            ICommand edit = new EditDataCommand(lastCellPressed, selection, e);
+//                            if (edit.canExecute()) {
+//                                edit.execute();
+//                                getInstance().getHistory().pushChange(edit);
+//                                treePanel.updateError("");
+//                            }
+//                            else {
+//                                treePanel.updateError(edit.getError());
+//                            }
+//                        }
+//                        else {
+//                            ClueCommand edit = new ClueCommand(selection, (TreeTentClueView) dragStart);
+//                            if (edit.canExecute()) {
+//                                edit.execute();
+//                                getInstance().getHistory().pushChange(edit);
+//                                treePanel.updateError("");
+//                            }
+//                            else {
+//                                treePanel.updateError(edit.getError());
+//                            }
+//                        }
+//                    }
+//                    else {
+//                        if (lastCellPressed != null) {
+//                            if (dragStart instanceof TreeTentElementView) {
+//                                ICommand editLine = new EditLineCommand(selection, (TreeTentElementView) dragStart, lastCellPressed);
+//                                if (editLine.canExecute()) {
+//                                    editLine.execute();
+//                                    getInstance().getHistory().pushChange(editLine);
+//                                }
+//                                else {
+//                                    treePanel.updateError(editLine.getError());
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//            dragStart = null;
+//            lastCellPressed = null;
+//        }
+//    }
 
     @Override
     public void changeCell(MouseEvent e, PuzzleElement element) {

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentExporter.java
@@ -12,7 +12,13 @@ public class TreeTentExporter extends PuzzleExporter {
 
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        TreeTentBoard board = (TreeTentBoard) puzzle.getTree().getRootNode().getBoard();
+        TreeTentBoard board;
+        if(puzzle.getTree() != null) {
+            board = (TreeTentBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (TreeTentBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("width", String.valueOf(board.getWidth()));
@@ -33,7 +39,7 @@ public class TreeTentExporter extends PuzzleExporter {
         for (TreeTentClue clue : board.getRowClues()) {
             org.w3c.dom.Element clueElement = newDocument.createElement("clue");
             clueElement.setAttribute("value", String.valueOf(clue.getData()));
-            clueElement.setAttribute("index", TreeTentClue.colNumToString(clue.getIndex()));
+            clueElement.setAttribute("index", TreeTentClue.colNumToString(clue.getClueIndex()));
             axisEast.appendChild(clueElement);
         }
         boardElement.appendChild(axisEast);
@@ -43,7 +49,7 @@ public class TreeTentExporter extends PuzzleExporter {
         for (TreeTentClue clue : board.getRowClues()) {
             org.w3c.dom.Element clueElement = newDocument.createElement("clue");
             clueElement.setAttribute("value", String.valueOf(clue.getData()));
-            clueElement.setAttribute("index", String.valueOf(clue.getIndex()));
+            clueElement.setAttribute("index", String.valueOf(clue.getClueIndex()));
             axisSouth.appendChild(clueElement);
         }
         boardElement.appendChild(axisSouth);

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentImporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentImporter.java
@@ -36,11 +36,11 @@ public class TreeTentImporter extends PuzzleImporter {
         }
 
         for (int i = 0; i < rows; i++) {
-            treeTentBoard.getRowClues().set(i, new TreeTentClue(0, i, TreeTentType.CLUE_EAST));
+            treeTentBoard.getRowClues().set(i, new TreeTentClue(0, i + 1, TreeTentType.CLUE_EAST));
         }
 
         for (int i = 0; i < columns; i++) {
-            treeTentBoard.getColClues().set(i, new TreeTentClue(0, i, TreeTentType.CLUE_SOUTH));
+            treeTentBoard.getColClues().set(i, new TreeTentClue(0, i + 1, TreeTentType.CLUE_SOUTH));
         }
 
         puzzle.setCurrentBoard(treeTentBoard);

--- a/src/main/java/edu/rpi/legup/ui/CreatePuzzleDialog.java
+++ b/src/main/java/edu/rpi/legup/ui/CreatePuzzleDialog.java
@@ -28,7 +28,7 @@ public class CreatePuzzleDialog extends JDialog {
          */
         @Override
         public void actionPerformed(ActionEvent e) {
-            String game = (String) gameBox.getSelectedItem();
+            String game = Config.convertDisplayNameToClassName((String) gameBox.getSelectedItem());
             try {
                 homePanel.openEditorWithNewPuzzle(game, Integer.valueOf(rows.getText()), Integer.valueOf(columns.getText()));
                 setVisible(false);


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Treetent puzzles can now be edited and saved in the puzzle editor.
<!-- If your pull request is not related to a particular issue, delete the statement below. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
