### PR TITLE
Fix Must Light Bug (Self Justification)

### DIFF
--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
@@ -52,7 +52,6 @@ public class MustLightBasicRule extends BasicRule {
     }
 
     private boolean isForcedBulb(LightUpBoard board, Point loc) {
-        CannotLightACellContradictionRule cannotLite = new CannotLightACellContradictionRule();
         LightUpCell cell = board.getCell(loc.x, loc.y);
         //Check if this cell itself (the one with the bulb) has no other lighting option
         if ((cell.getType() == LightUpCellType.EMPTY || cell.getType() == LightUpCellType.UNKNOWN) &&
@@ -114,6 +113,14 @@ public class MustLightBasicRule extends BasicRule {
         return false;
     }
 
+    /**
+     * Checks the number of cells that can contain a bulb that lights the given cell
+     *
+     * @param board    transition to check
+     * @param cell index of the puzzleElement
+     * @return -1 if the cell is already lit,
+     * otherwise the number of that can contain a bulb that lights the given cell
+     */
     public int countPossibleBulbs(LightUpBoard board, LightUpCell cell) {
         if (cell.isLite()) {
             return -1;
@@ -121,6 +128,7 @@ public class MustLightBasicRule extends BasicRule {
         Point location = cell.getLocation();
         int ver_count = 0;
         int hor_count = 0;
+        //Look right
         for (int i = location.x + 1; i < board.getWidth(); i++) {
             LightUpCell c = board.getCell(i, location.y);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
@@ -132,6 +140,7 @@ public class MustLightBasicRule extends BasicRule {
                 }
             }
         }
+        //Look left
         for (int i = location.x - 1; i >= 0; i--) {
             LightUpCell c = board.getCell(i, location.y);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
@@ -143,6 +152,7 @@ public class MustLightBasicRule extends BasicRule {
                 }
             }
         }
+        //Look down
         for (int i = location.y + 1; i < board.getHeight(); i++) {
             LightUpCell c = board.getCell(location.x, i);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
@@ -154,6 +164,7 @@ public class MustLightBasicRule extends BasicRule {
                 }
             }
         }
+        //Look up
         for (int i = location.y - 1; i >= 0; i--) {
             LightUpCell c = board.getCell(location.x, i);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
@@ -38,7 +38,6 @@ public class MustLightBasicRule extends BasicRule {
             return super.getInvalidUseOfRuleMessage() + ": Modified cells must be bulbs";
         }
 
-        finalCell.setData(LightUpCellType.EMPTY.value);
         finalBoard.fillWithLight();
         boolean isForced = isForcedBulb(parentBoard, finalCell.getLocation());
         finalCell.setData(LightUpCellType.BULB.value);
@@ -55,10 +54,12 @@ public class MustLightBasicRule extends BasicRule {
     private boolean isForcedBulb(LightUpBoard board, Point loc) {
         CannotLightACellContradictionRule cannotLite = new CannotLightACellContradictionRule();
         LightUpCell cell = board.getCell(loc.x, loc.y);
+        //Check if this cell itself (the one with the bulb) has no other lighting option
         if ((cell.getType() == LightUpCellType.EMPTY || cell.getType() == LightUpCellType.UNKNOWN) &&
-                !cell.isLite() && cannotLite.checkContradictionAt(board, cell) == null) {
+                !cell.isLite() && countPossibleBulbs(board, cell) == 0) {
             return true;
         }
+        //Look right
         for (int i = loc.x + 1; i < board.getWidth(); i++) {
             LightUpCell c = board.getCell(i, loc.y);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
@@ -66,11 +67,12 @@ public class MustLightBasicRule extends BasicRule {
             }
             else {
                 if (c.getType() == LightUpCellType.EMPTY &&
-                        !c.isLite() && cannotLite.checkContradictionAt(board, c) == null) {
+                        !c.isLite() && countPossibleBulbs(board, c) == 1) {
                     return true;
                 }
             }
         }
+        //Look left
         for (int i = loc.x - 1; i >= 0; i--) {
             LightUpCell c = board.getCell(i, loc.y);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
@@ -78,11 +80,12 @@ public class MustLightBasicRule extends BasicRule {
             }
             else {
                 if (c.getType() == LightUpCellType.EMPTY &&
-                        !c.isLite() && cannotLite.checkContradictionAt(board, c) == null) {
+                        !c.isLite() && countPossibleBulbs(board, c) == 1) {
                     return true;
                 }
             }
         }
+        //Look down
         for (int i = loc.y + 1; i < board.getHeight(); i++) {
             LightUpCell c = board.getCell(loc.x, i);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
@@ -90,11 +93,12 @@ public class MustLightBasicRule extends BasicRule {
             }
             else {
                 if (c.getType() == LightUpCellType.EMPTY &&
-                        !c.isLite() && cannotLite.checkContradictionAt(board, c) == null) {
+                        !c.isLite() && countPossibleBulbs(board, c) == 1) {
                     return true;
                 }
             }
         }
+        //Look up
         for (int i = loc.y - 1; i >= 0; i--) {
             LightUpCell c = board.getCell(loc.x, i);
             if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
@@ -102,12 +106,66 @@ public class MustLightBasicRule extends BasicRule {
             }
             else {
                 if (c.getType() == LightUpCellType.EMPTY &&
-                        !c.isLite() && cannotLite.checkContradictionAt(board, c) == null) {
+                        !c.isLite() && countPossibleBulbs(board, c) == 1) {
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    public int countPossibleBulbs(LightUpBoard board, LightUpCell cell) {
+        if (cell.isLite()) {
+            return -1;
+        }
+        Point location = cell.getLocation();
+        int ver_count = 0;
+        int hor_count = 0;
+        for (int i = location.x + 1; i < board.getWidth(); i++) {
+            LightUpCell c = board.getCell(i, location.y);
+            if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
+                break;
+            }
+            else {
+                if (c.getType() == LightUpCellType.UNKNOWN && !c.isLite()) {
+                    hor_count += 1;
+                }
+            }
+        }
+        for (int i = location.x - 1; i >= 0; i--) {
+            LightUpCell c = board.getCell(i, location.y);
+            if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
+                break;
+            }
+            else {
+                if (c.getType() == LightUpCellType.UNKNOWN && !c.isLite()) {
+                    hor_count += 1;
+                }
+            }
+        }
+        for (int i = location.y + 1; i < board.getHeight(); i++) {
+            LightUpCell c = board.getCell(location.x, i);
+            if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
+                break;
+            }
+            else {
+                if (c.getType() == LightUpCellType.UNKNOWN && !c.isLite()) {
+                    ver_count += 1;
+                }
+            }
+        }
+        for (int i = location.y - 1; i >= 0; i--) {
+            LightUpCell c = board.getCell(location.x, i);
+            if (c.getType() == LightUpCellType.BLACK || c.getType() == LightUpCellType.NUMBER) {
+                break;
+            }
+            else {
+                if (c.getType() == LightUpCellType.UNKNOWN && !c.isLite()) {
+                    ver_count += 1;
+                }
+            }
+        }
+        return hor_count + ver_count;
     }
 
     /**

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/rules/MustLightBasicRule.java
@@ -40,7 +40,7 @@ public class MustLightBasicRule extends BasicRule {
 
         finalCell.setData(LightUpCellType.EMPTY.value);
         finalBoard.fillWithLight();
-        boolean isForced = isForcedBulb(finalBoard, finalCell.getLocation());
+        boolean isForced = isForcedBulb(parentBoard, finalCell.getLocation());
         finalCell.setData(LightUpCellType.BULB.value);
         finalBoard.fillWithLight();
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
The MustLight rule used the `finalBoard` to determine the rule's use. Now the `parentBoard` is the only board referenced when using the rule.
Closes #119 

NOTE: 
None of the puzzles should allow a final state to determine whether a rule can be used. If any other puzzles were to do that, that rule would have this same self-justification issue (#120).
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
