### PR TITLE
Go to home screen when close puzzle editor File Explorer  

### DIFF
--- a/src/main/java/edu/rpi/legup/controller/EditorElementController.java
+++ b/src/main/java/edu/rpi/legup/controller/EditorElementController.java
@@ -57,10 +57,14 @@ public class EditorElementController implements ActionListener {
         ElementButton button = (ElementButton) lastSource;
         buttonPressed(button.getElement());
 
+        // reset border in previous selected button
         if (this.prevButton != null) {
             this.prevButton.resetBorder();
         }
+
+        // change border color when select a button
         button.setBorderToSelected();
+
         this.prevButton = button;
 
     }

--- a/src/main/java/edu/rpi/legup/controller/EditorElementController.java
+++ b/src/main/java/edu/rpi/legup/controller/EditorElementController.java
@@ -5,7 +5,9 @@ import edu.rpi.legup.app.LegupPreferences;
 import edu.rpi.legup.history.*;
 import edu.rpi.legup.model.Puzzle;
 import edu.rpi.legup.model.elements.Element;
+import edu.rpi.legup.model.gameboard.Board;
 import edu.rpi.legup.model.gameboard.CaseBoard;
+import edu.rpi.legup.model.gameboard.PuzzleElement;
 import edu.rpi.legup.model.rules.*;
 import edu.rpi.legup.model.tree.TreeElement;
 import edu.rpi.legup.model.tree.TreeElementType;
@@ -17,6 +19,8 @@ import edu.rpi.legup.ui.proofeditorui.treeview.TreeViewSelection;
 import edu.rpi.legup.ui.puzzleeditorui.elementsview.ElementButton;
 
 import javax.swing.*;
+import javax.swing.border.Border;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
@@ -26,10 +30,12 @@ import static edu.rpi.legup.app.GameBoardFacade.getInstance;
 public class EditorElementController implements ActionListener {
     protected Object lastSource;
     protected ElementController elementController;
+    protected ElementButton prevButton;
 
     public EditorElementController() {
         super();
         elementController = null;
+        prevButton = null;
     }
 
     public void setElementController(ElementController elementController) {
@@ -38,6 +44,7 @@ public class EditorElementController implements ActionListener {
 
     public void buttonPressed(Element element) {
         // TODO: implement what happens when element is pressed
+
         System.out.printf("%s button pressed!\n", element.getElementName());
         if (elementController != null) {
             elementController.setSelectedElement(element);
@@ -49,5 +56,12 @@ public class EditorElementController implements ActionListener {
         lastSource = e.getSource();
         ElementButton button = (ElementButton) lastSource;
         buttonPressed(button.getElement());
+
+        if (this.prevButton != null) {
+            this.prevButton.resetBorder();
+        }
+        button.setBorderToSelected();
+        this.prevButton = button;
+
     }
 }

--- a/src/main/java/edu/rpi/legup/ui/HomePanel.java
+++ b/src/main/java/edu/rpi/legup/ui/HomePanel.java
@@ -41,6 +41,9 @@ public class HomePanel extends LegupPanel {
         @Override
         public void actionPerformed(ActionEvent e) {
             Object[] items = legupUI.getPuzzleEditor().promptPuzzle();
+            if (items == null) {
+                return;
+            }
             String fileName = (String) items[0];
             File puzzleFile = (File) items[1];
             legupUI.displayPanel(2);

--- a/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
+++ b/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
@@ -255,6 +255,9 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
             fileName = fileDialog.getDirectory() + File.separator + fileDialog.getFile();
             puzzleFile = new File(fileName);
         }
+        else {
+            return null;
+        }
 
         return new Object[]{fileName, puzzleFile};
     }

--- a/src/main/java/edu/rpi/legup/ui/puzzleeditorui/elementsview/ElementButton.java
+++ b/src/main/java/edu/rpi/legup/ui/puzzleeditorui/elementsview/ElementButton.java
@@ -4,14 +4,18 @@ import edu.rpi.legup.model.elements.Element;
 import edu.rpi.legup.model.rules.Rule;
 
 import javax.swing.*;
+import javax.swing.border.Border;
+import java.awt.*;
 
 public class ElementButton extends JButton {
 
     private Element element;
+    private final Border originalBorder;
 
     ElementButton(Element e) {
         super(e.getImageIcon());
         this.element = e;
+        this.originalBorder = this.getBorder();
     }
 
     public Element getElement() {
@@ -20,5 +24,15 @@ public class ElementButton extends JButton {
 
     public void setElement(Element e) {
         this.element = e;
+    }
+
+    public void setBorderToSelected() {
+        Border newBorderIn = BorderFactory.createLineBorder(new Color(20, 140, 70), 2, true);
+        Border newBorder = BorderFactory.createCompoundBorder(newBorderIn, this.originalBorder);
+        this.setBorder(newBorder);
+    }
+
+    public void resetBorder() {
+        this.setBorder(this.originalBorder);
     }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fix the issue where legup does not go back to home screen when close puzzle editor file explorer.


<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes 307(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
