### PR TITLE
`UnreachableWhiteCellContradictionRule` Pathfinding

### DIFF
--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
@@ -312,10 +312,10 @@ public class NurikabeUtilities {
                 }
             }
             // Map the cells to the center-size (including the center)
-            whiteRegionMap.put(center,center.getType().toValue()-size);
+            whiteRegionMap.put(center,center.getData()-size);
             for (NurikabeCell member : connected)
             {
-                whiteRegionMap.put(member,center.getType().toValue()-size);
+                whiteRegionMap.put(member,center.getData()-size);
             }
         }
         return whiteRegionMap;

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
@@ -249,7 +249,6 @@ public class NurikabeUtilities {
         int height = board.getHeight();
 
         Set<NurikabeCell> numberedCells = getNurikabeNumberedCells(board);
-        //HashMap<NurikabeCell,NurikabeCell> cellCenterMap = new HashMap<NurikabeCell,NurikabeCell>();
         // Final mapping of cell to size
         HashMap<NurikabeCell,Integer> whiteRegionMap = new HashMap<>();
         for (NurikabeCell center: numberedCells) {
@@ -305,7 +304,6 @@ public class NurikabeUtilities {
                     if (!visited.getOrDefault(n,false)
                             && n.getType() == NurikabeType.WHITE)
                     {
-                        //cellCenterMap.put(n,center);
                         connected.add(n);
                         visited.put(n,true);
                         queue.add(n);
@@ -313,6 +311,7 @@ public class NurikabeUtilities {
                     }
                 }
             }
+            // Map the cells to the size-center (including the center)
             whiteRegionMap.put(center,size-center.getType().toValue());
             for (NurikabeCell member : connected)
             {

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
@@ -4,7 +4,6 @@ import edu.rpi.legup.model.gameboard.PuzzleElement;
 import edu.rpi.legup.utility.DisjointSets;
 
 import java.awt.*;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -167,82 +166,12 @@ public class NurikabeUtilities {
     }
 
     /**
-     * Gets a list of flood filled white regions with remaining white cells
-     *
-     * @param board nurikabe board
-     * @return a list of flood filled white regions
-     */
-    public static ArrayList<Set<NurikabeCell>> getFloodFillWhite(NurikabeBoard board) {
-        int width = board.getWidth();
-        int height = board.getHeight();
-
-        DisjointSets<NurikabeCell> whiteRegions = new DisjointSets<>();
-        for (PuzzleElement data : board.getPuzzleElements()) {
-            NurikabeCell cell = (NurikabeCell) data;
-            whiteRegions.createSet(cell);
-        }
-
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                NurikabeCell cell = board.getCell(x, y);
-                NurikabeCell rightCell = board.getCell(x + 1, y);
-                NurikabeCell downCell = board.getCell(x, y + 1);
-                if (cell.getType() == NurikabeType.WHITE || cell.getType() == NurikabeType.NUMBER) {
-                    if (rightCell != null && (rightCell.getType() == NurikabeType.WHITE ||
-                            rightCell.getType() == NurikabeType.NUMBER)) {
-                        whiteRegions.union(cell, rightCell);
-                    }
-                    if (downCell != null && (downCell.getType() == NurikabeType.WHITE ||
-                            downCell.getType() == NurikabeType.NUMBER)) {
-                        whiteRegions.union(cell, downCell);
-                    }
-                }
-            }
-        }
-
-        Set<NurikabeCell> numberedCells = getNurikabeNumberedCells(board);
-        ArrayList<Set<NurikabeCell>> floodFilledRegions = new ArrayList<>();
-        for (NurikabeCell numberCell : numberedCells) {
-            int number = numberCell.getData();
-            Set<NurikabeCell> region = whiteRegions.getSet(numberCell);
-            floodFilledRegions.add(region);
-
-            int flood = number - region.size();
-            for (int i = 0; i < flood; i++) {
-                Set<NurikabeCell> newSet = new HashSet<>();
-                for (NurikabeCell c : region) {
-                    Point loc = c.getLocation();
-                    NurikabeCell upCell = board.getCell(loc.x, loc.y - 1);
-                    NurikabeCell rightCell = board.getCell(loc.x + 1, loc.y);
-                    NurikabeCell downCell = board.getCell(loc.x, loc.y + 1);
-                    NurikabeCell leftCell = board.getCell(loc.x - 1, loc.y);
-                    if (upCell != null) {
-                        newSet.add(upCell);
-                    }
-                    if (rightCell != null) {
-                        newSet.add(rightCell);
-                    }
-                    if (downCell != null) {
-                        newSet.add(downCell);
-                    }
-                    if (leftCell != null) {
-                        newSet.add(leftCell);
-                    }
-                }
-                region.addAll(newSet);
-            }
-        }
-
-        return floodFilledRegions;
-    }
-
-    /**
-     * Gets a map where the keys are white/numbered cells
+     * Makes a map where the keys are white/numbered cells
      * and the values are the amount of cells that need
      * to be added to the region
      *
      * @param board nurikabe board
-     * @return a list of flood filled white regions
+     * @return a map of cell keys to integer values
      */
     public static HashMap<NurikabeCell,Integer> getWhiteRegionMap(NurikabeBoard board) {
         int width = board.getWidth();

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
@@ -276,7 +276,7 @@ public class NurikabeUtilities {
                 System.out.print(s+" ");
 
                 // Make a linked list of all adjacent squares
-                LinkedList<NurikabeCell> adj = new LinkedList<>();
+                Set<NurikabeCell> adj = new HashSet<>();
 
                 Point loc = s.getLocation();
                 // First check if the side is on the board
@@ -311,11 +311,11 @@ public class NurikabeUtilities {
                     }
                 }
             }
-            // Map the cells to the size-center (including the center)
-            whiteRegionMap.put(center,size-center.getType().toValue());
+            // Map the cells to the center-size (including the center)
+            whiteRegionMap.put(center,center.getType().toValue()-size);
             for (NurikabeCell member : connected)
             {
-                whiteRegionMap.put(member,size-center.getType().toValue());
+                whiteRegionMap.put(member,center.getType().toValue()-size);
             }
         }
         return whiteRegionMap;

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
@@ -5,7 +5,9 @@ import edu.rpi.legup.utility.DisjointSets;
 
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Set;
 
 public class NurikabeUtilities {
@@ -232,5 +234,91 @@ public class NurikabeUtilities {
         }
 
         return floodFilledRegions;
+    }
+
+    /**
+     * Gets a map where the keys are white/numbered cells
+     * and the values are the amount of cells that need
+     * to be added to the region
+     *
+     * @param board nurikabe board
+     * @return a list of flood filled white regions
+     */
+    public static HashMap<NurikabeCell,Integer> getWhiteRegionMap(NurikabeBoard board) {
+        int width = board.getWidth();
+        int height = board.getHeight();
+
+        Set<NurikabeCell> numberedCells = getNurikabeNumberedCells(board);
+        //HashMap<NurikabeCell,NurikabeCell> cellCenterMap = new HashMap<NurikabeCell,NurikabeCell>();
+        // Final mapping of cell to size
+        HashMap<NurikabeCell,Integer> whiteRegionMap = new HashMap<>();
+        for (NurikabeCell center: numberedCells) {
+            //BFS for each center to find the size of the region
+            int size = 1;
+            // Mark all the vertices as not visited(By default
+            // set as false)
+            HashMap<NurikabeCell,Boolean> visited= new HashMap<>();
+
+            // Create a queue for BFS
+            LinkedList<NurikabeCell> queue = new LinkedList<>();
+
+            // Mark the current node as visited and enqueue it
+            visited.put(center,true);
+            queue.add(center);
+
+            // Set of cells in the current region
+            Set<NurikabeCell> connected = new HashSet<>();
+
+            while (queue.size() != 0)
+            {
+                // Dequeue a vertex from queue and print it
+                // s is the source node in the graph
+                NurikabeCell s = queue.poll();
+                System.out.print(s+" ");
+
+                // Make a linked list of all adjacent squares
+                LinkedList<NurikabeCell> adj = new LinkedList<>();
+
+                Point loc = s.getLocation();
+                // First check if the side is on the board
+                if (loc.x >= 1)
+                {
+                    adj.add(board.getCell(loc.x-1, loc.y));
+                }
+                if (loc.x < width-1)
+                {
+                    adj.add(board.getCell(loc.x+1, loc.y));
+                }
+                if (loc.y >= 1)
+                {
+                    adj.add(board.getCell(loc.x, loc.y-1));
+                }
+                if (loc.y < height-1)
+                {
+                    adj.add(board.getCell(loc.x, loc.y+1));
+                }
+                // Get all adjacent vertices of the dequeued vertex s
+                // If a adjacent has not been visited, then mark it
+                // visited and enqueue it
+                for (NurikabeCell n : adj)
+                {
+                    if (!visited.getOrDefault(n,false)
+                            && n.getType() == NurikabeType.WHITE)
+                    {
+                        //cellCenterMap.put(n,center);
+                        connected.add(n);
+                        visited.put(n,true);
+                        queue.add(n);
+                        ++size;
+                    }
+                }
+            }
+            whiteRegionMap.put(center,size-center.getType().toValue());
+            for (NurikabeCell member : connected)
+            {
+                whiteRegionMap.put(member,size-center.getType().toValue());
+            }
+        }
+        return whiteRegionMap;
     }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
@@ -197,8 +197,7 @@ public class NurikabeUtilities {
             // Set of cells in the current region
             Set<NurikabeCell> connected = new HashSet<>();
 
-            while (queue.size() != 0)
-            {
+            while (queue.size() != 0) {
                 // Dequeue a vertex from queue and print it
                 // s is the source node in the graph
                 NurikabeCell s = queue.poll();
@@ -209,30 +208,24 @@ public class NurikabeUtilities {
 
                 Point loc = s.getLocation();
                 // First check if the side is on the board
-                if (loc.x >= 1)
-                {
+                if (loc.x >= 1) {
                     adj.add(board.getCell(loc.x-1, loc.y));
                 }
-                if (loc.x < width-1)
-                {
+                if (loc.x < width-1) {
                     adj.add(board.getCell(loc.x+1, loc.y));
                 }
-                if (loc.y >= 1)
-                {
+                if (loc.y >= 1) {
                     adj.add(board.getCell(loc.x, loc.y-1));
                 }
-                if (loc.y < height-1)
-                {
+                if (loc.y < height-1) {
                     adj.add(board.getCell(loc.x, loc.y+1));
                 }
                 // Get all adjacent vertices of the dequeued vertex s
                 // If a adjacent has not been visited, then mark it
                 // visited and enqueue it
-                for (NurikabeCell n : adj)
-                {
+                for (NurikabeCell n : adj) {
                     if (!visited.getOrDefault(n,false)
-                            && n.getType() == NurikabeType.WHITE)
-                    {
+                            && n.getType() == NurikabeType.WHITE) {
                         connected.add(n);
                         visited.put(n,true);
                         queue.add(n);
@@ -242,8 +235,7 @@ public class NurikabeUtilities {
             }
             // Map the cells to the center-size (including the center)
             whiteRegionMap.put(center,center.getData()-size);
-            for (NurikabeCell member : connected)
-            {
+            for (NurikabeCell member : connected) {
                 whiteRegionMap.put(member,center.getData()-size);
             }
         }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CannotReachCellBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CannotReachCellBasicRule.java
@@ -53,7 +53,7 @@ public class CannotReachCellBasicRule extends BasicRule {
         if (contraRule.checkContradiction(modified) == null) {
             return null;
         }
-        return super.getInvalidUseOfRuleMessage() + ": This is not the only way for black to escape!";
+        return super.getInvalidUseOfRuleMessage() + ": Cell at this index can be reached";
     }
 
     /**

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CannotReachCellBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CannotReachCellBasicRule.java
@@ -42,7 +42,7 @@ public class CannotReachCellBasicRule extends BasicRule {
 
         NurikabeCell modifiedCell = (NurikabeCell) modified.getPuzzleElement(puzzleElement);
         modifiedCell.setData(NurikabeType.WHITE.toValue());
-        if (contraRule.checkContradiction(modified) == null) {
+        if (contraRule.checkContradictionAt(modified,modifiedCell) == null) {
             return null;
         }
         return super.getInvalidUseOfRuleMessage() + ": Cell at this index can be reached";

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CannotReachCellBasicRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CannotReachCellBasicRule.java
@@ -40,14 +40,6 @@ public class CannotReachCellBasicRule extends BasicRule {
         NurikabeBoard origBoardState = (NurikabeBoard) transition.getParents().get(0).getBoard();
         NurikabeBoard modified = origBoardState.copy();
 
-        for (int i = 0; i < modified.getWidth(); i++) {
-            for (int j = 0; j < modified.getHeight(); j++) {
-                NurikabeCell currentCell = modified.getCell(i, j);
-                if (currentCell.getType() == NurikabeType.WHITE) {
-                    currentCell.setData(NurikabeType.UNKNOWN.toValue());
-                }
-            }
-        }
         NurikabeCell modifiedCell = (NurikabeCell) modified.getPuzzleElement(puzzleElement);
         modifiedCell.setData(NurikabeType.WHITE.toValue());
         if (contraRule.checkContradiction(modified) == null) {

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
@@ -45,8 +45,7 @@ public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
 
         // Get regions
         HashMap<NurikabeCell,Integer> whiteRegionMap = NurikabeUtilities.getWhiteRegionMap(nurikabeBoard);
-        if (whiteRegionMap.containsKey(cell))
-        {
+        if (whiteRegionMap.containsKey(cell)) {
             return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
         }
         // BFS to a region
@@ -59,36 +58,29 @@ public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
         visited.put(cell,true);
         queue.add(cell);
         int pathLength = 1;
-        while (queue.size() != 0)
-        {
+        while (queue.size() != 0) {
             // Set of adjacent squares
             Set<NurikabeCell> adj = new HashSet<>();
-            while (queue.size() != 0)
-            {
+            while (queue.size() != 0) {
                 // Dequeue a vertex from queue and print it
                 NurikabeCell s = queue.poll();
 
                 Point loc = s.getLocation();
                 // First check if the side is on the board
-                if (loc.x >= 1)
-                {
+                if (loc.x >= 1) {
                     adj.add(nurikabeBoard.getCell(loc.x-1, loc.y));
                 }
-                if (loc.x < width-1)
-                {
+                if (loc.x < width-1) {
                     adj.add(nurikabeBoard.getCell(loc.x+1, loc.y));
                 }
-                if (loc.y >= 1)
-                {
+                if (loc.y >= 1) {
                     adj.add(nurikabeBoard.getCell(loc.x, loc.y-1));
                 }
-                if (loc.y < height-1)
-                {
+                if (loc.y < height-1) {
                     adj.add(nurikabeBoard.getCell(loc.x, loc.y+1));
                 }
 
-                for (NurikabeCell n :adj)
-                {
+                for (NurikabeCell n :adj) {
                     int regionNeed = whiteRegionMap.getOrDefault(n,-1);
                     if (pathLength <= regionNeed)
                     {
@@ -97,12 +89,10 @@ public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
                 }
             }
 
-            for (NurikabeCell n : adj)
-            {
+            for (NurikabeCell n : adj) {
                 if (!visited.getOrDefault(n,false)
                         && (n.getType() == NurikabeType.UNKNOWN ||
-                        n.getType() == NurikabeType.WHITE))
-                {
+                        n.getType() == NurikabeType.WHITE)) {
                     visited.put(n,true);
                     queue.add(n);
                 }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
@@ -43,10 +43,8 @@ public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
         ArrayList<Set<NurikabeCell>> regions = NurikabeUtilities.getFloodFillWhite(nurikabeBoard);
 
         for (Set<NurikabeCell> region : regions) {
-            for (NurikabeCell c : region) {
-                if (c == cell) {
-                    return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
-                }
+            if (region.contains(cell)) {
+                return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
             }
         }
 

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
@@ -8,8 +8,8 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeCell;
 import edu.rpi.legup.puzzle.nurikabe.NurikabeType;
 import edu.rpi.legup.puzzle.nurikabe.NurikabeUtilities;
 
-import java.util.ArrayList;
-import java.util.Set;
+import java.awt.*;
+import java.util.*;
 
 public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
 
@@ -40,12 +40,73 @@ public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
             return super.getInvalidUseOfRuleMessage() + ": " + this.INVALID_USE_MESSAGE;
         }
 
-        ArrayList<Set<NurikabeCell>> regions = NurikabeUtilities.getFloodFillWhite(nurikabeBoard);
+        int height = nurikabeBoard.getHeight();
+        int width = nurikabeBoard.getWidth();
 
-        for (Set<NurikabeCell> region : regions) {
-            if (region.contains(cell)) {
-                return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
+        // Get regions
+        HashMap<NurikabeCell,Integer> whiteRegionMap = NurikabeUtilities.getWhiteRegionMap(nurikabeBoard);
+        // BFS to a region
+
+        // Create a queue for BFS
+        LinkedList<NurikabeCell> queue = new LinkedList<>();
+
+        // Mark the current node as visited and enqueue it
+        HashMap<NurikabeCell,Boolean> visited= new HashMap<>();
+        visited.put(cell,true);
+        queue.add(cell);
+        int pathLength = 1;
+        while (queue.size() != 0)
+        {
+            // Dequeue a vertex from queue and print it
+            NurikabeCell s = queue.poll();
+            System.out.print(s+" ");
+
+            // Get all adjacent vertices of the dequeued vertex s
+            // If a adjacent has not been visited, then mark it
+            // visited and enqueue it
+
+            // Make a linked list of all adjacent squares
+            Set<NurikabeCell> adj = new HashSet<>();
+
+            Point loc = s.getLocation();
+            // First check if the side is on the board
+            if (loc.x >= 1)
+            {
+                adj.add(nurikabeBoard.getCell(loc.x-1, loc.y));
             }
+            if (loc.x < width-1)
+            {
+                adj.add(nurikabeBoard.getCell(loc.x+1, loc.y));
+            }
+            if (loc.y >= 1)
+            {
+                adj.add(nurikabeBoard.getCell(loc.x, loc.y-1));
+            }
+            if (loc.y < height-1)
+            {
+                adj.add(nurikabeBoard.getCell(loc.x, loc.y+1));
+            }
+
+            for (NurikabeCell n :adj)
+            {
+                int regionNeed = whiteRegionMap.getOrDefault(n,-1);
+                if (pathLength <= regionNeed)
+                {
+                    return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
+                }
+            }
+
+            for (NurikabeCell n : adj)
+            {
+                if (!visited.getOrDefault(n,false)
+                        && (n.getType() == NurikabeType.UNKNOWN ||
+                        n.getType() == NurikabeType.WHITE))
+                {
+                    visited.put(n,true);
+                    queue.add(n);
+                }
+            }
+            ++pathLength;
         }
 
         return null;

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/UnreachableWhiteCellContradictionRule.java
@@ -45,6 +45,10 @@ public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
 
         // Get regions
         HashMap<NurikabeCell,Integer> whiteRegionMap = NurikabeUtilities.getWhiteRegionMap(nurikabeBoard);
+        if (whiteRegionMap.containsKey(cell))
+        {
+            return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
+        }
         // BFS to a region
 
         // Create a queue for BFS
@@ -57,42 +61,39 @@ public class UnreachableWhiteCellContradictionRule extends ContradictionRule {
         int pathLength = 1;
         while (queue.size() != 0)
         {
-            // Dequeue a vertex from queue and print it
-            NurikabeCell s = queue.poll();
-            System.out.print(s+" ");
-
-            // Get all adjacent vertices of the dequeued vertex s
-            // If a adjacent has not been visited, then mark it
-            // visited and enqueue it
-
-            // Make a linked list of all adjacent squares
+            // Set of adjacent squares
             Set<NurikabeCell> adj = new HashSet<>();
+            while (queue.size() != 0)
+            {
+                // Dequeue a vertex from queue and print it
+                NurikabeCell s = queue.poll();
 
-            Point loc = s.getLocation();
-            // First check if the side is on the board
-            if (loc.x >= 1)
-            {
-                adj.add(nurikabeBoard.getCell(loc.x-1, loc.y));
-            }
-            if (loc.x < width-1)
-            {
-                adj.add(nurikabeBoard.getCell(loc.x+1, loc.y));
-            }
-            if (loc.y >= 1)
-            {
-                adj.add(nurikabeBoard.getCell(loc.x, loc.y-1));
-            }
-            if (loc.y < height-1)
-            {
-                adj.add(nurikabeBoard.getCell(loc.x, loc.y+1));
-            }
-
-            for (NurikabeCell n :adj)
-            {
-                int regionNeed = whiteRegionMap.getOrDefault(n,-1);
-                if (pathLength <= regionNeed)
+                Point loc = s.getLocation();
+                // First check if the side is on the board
+                if (loc.x >= 1)
                 {
-                    return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
+                    adj.add(nurikabeBoard.getCell(loc.x-1, loc.y));
+                }
+                if (loc.x < width-1)
+                {
+                    adj.add(nurikabeBoard.getCell(loc.x+1, loc.y));
+                }
+                if (loc.y >= 1)
+                {
+                    adj.add(nurikabeBoard.getCell(loc.x, loc.y-1));
+                }
+                if (loc.y < height-1)
+                {
+                    adj.add(nurikabeBoard.getCell(loc.x, loc.y+1));
+                }
+
+                for (NurikabeCell n :adj)
+                {
+                    int regionNeed = whiteRegionMap.getOrDefault(n,-1);
+                    if (pathLength <= regionNeed)
+                    {
+                        return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes #300

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Both the `UnreachableWhiteCellContradictionRule` and its corresponding `CannotReachCell` basic rule will now be able to use any black and/or numbered cells to determine that a cell isn't reachable from any region. 
![image](https://user-images.githubusercontent.com/60408336/194675787-6c8834f3-dbc6-49ab-a2a4-83e4378824cd.png)
This is a screenshot of this proof file: 
[prtestproof.zip](https://github.com/Bram-Hub/Legup/files/9737907/prtestproof.zip)

If I instead try to choose every square for the rule, I'm shown exactly which ones can and can't be reached.
![image](https://user-images.githubusercontent.com/60408336/194676123-ca57e887-3587-4ef5-b665-3f36abb60886.png)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
