### PR TITLE
Add verification of the board before saving a puzzle file from the puzzle editor

### DIFF
--- a/src/main/java/edu/rpi/legup/model/Puzzle.java
+++ b/src/main/java/edu/rpi/legup/model/Puzzle.java
@@ -639,8 +639,10 @@ public abstract class Puzzle implements IBoardSubject, ITreeSubject {
         treeListeners.forEach(algorithm);
     }
 
-    public boolean checkValidity()
-    {
-        return true;
-    }
+    /**
+     * Check if the puzzle is valid
+     *
+     * @return if the puzzle is valid
+     */
+    public abstract boolean checkValidity();
 }

--- a/src/main/java/edu/rpi/legup/model/Puzzle.java
+++ b/src/main/java/edu/rpi/legup/model/Puzzle.java
@@ -638,4 +638,9 @@ public abstract class Puzzle implements IBoardSubject, ITreeSubject {
     public void notifyTreeListeners(Consumer<? super ITreeListener> algorithm) {
         treeListeners.forEach(algorithm);
     }
+
+    public boolean checkValidity()
+    {
+        return true;
+    }
 }

--- a/src/main/java/edu/rpi/legup/model/Puzzle.java
+++ b/src/main/java/edu/rpi/legup/model/Puzzle.java
@@ -644,5 +644,7 @@ public abstract class Puzzle implements IBoardSubject, ITreeSubject {
      *
      * @return if the puzzle is valid
      */
-    public abstract boolean checkValidity();
+    public boolean checkValidity() {
+        return true;
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
@@ -79,6 +79,7 @@ public class TreeTent extends Puzzle {
      * @return if it is valid
      * TreeTent puzzle must have same number of clues as the dimension size
      */
+    @Override
     public boolean checkValidity() {
         TreeTentBoard b = (TreeTentBoard) this.getBoardView().getBoard();
         List<PuzzleElement> elements = b.getPuzzleElements();

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
@@ -2,6 +2,9 @@ package edu.rpi.legup.puzzle.treetent;
 
 import edu.rpi.legup.model.Puzzle;
 import edu.rpi.legup.model.gameboard.Board;
+import edu.rpi.legup.model.gameboard.PuzzleElement;
+
+import java.util.List;
 
 public class TreeTent extends Puzzle {
 
@@ -69,5 +72,25 @@ public class TreeTent extends Puzzle {
     @Override
     public void onBoardChange(Board board) {
 
+    }
+
+    /**
+
+     * @return if it is valid
+     * TreeTent puzzle must have same number of clues as the dimension size
+     */
+    @Override
+    public boolean checkValidity() {
+        TreeTentBoard b = (TreeTentBoard) this.getBoardView().getBoard();
+        List<PuzzleElement> elements = b.getPuzzleElements();
+        int puzzleElementCount = 0;
+        for (PuzzleElement element : elements) {
+            TreeTentCell c = (TreeTentCell) element;
+            if (c.getType() != TreeTentType.UNKNOWN) {
+                puzzleElementCount++;
+            }
+        }
+        int dim = b.getHeight();
+        return puzzleElementCount == dim;
     }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTent.java
@@ -79,7 +79,6 @@ public class TreeTent extends Puzzle {
      * @return if it is valid
      * TreeTent puzzle must have same number of clues as the dimension size
      */
-    @Override
     public boolean checkValidity() {
         TreeTentBoard b = (TreeTentBoard) this.getBoardView().getBoard();
         List<PuzzleElement> elements = b.getPuzzleElements();

--- a/src/main/java/edu/rpi/legup/ui/DynamicView.java
+++ b/src/main/java/edu/rpi/legup/ui/DynamicView.java
@@ -123,7 +123,7 @@ public class DynamicView extends JPanel {
             minus.setPreferredSize(new Dimension(20, 20));
             minus.setFont(MaterialFonts.getRegularFont(10f));
             minus.addActionListener((ActionEvent e) -> zoomSlider.setValue(zoomSlider.getValue() - 25));
-            this.scrollView.setWheelScrollingEnabled(false);
+            this.scrollView.setWheelScrollingEnabled(true);
 
             zoomSlider.setPreferredSize(new Dimension(160, 30));
 

--- a/src/main/java/edu/rpi/legup/ui/DynamicView.java
+++ b/src/main/java/edu/rpi/legup/ui/DynamicView.java
@@ -123,7 +123,7 @@ public class DynamicView extends JPanel {
             minus.setPreferredSize(new Dimension(20, 20));
             minus.setFont(MaterialFonts.getRegularFont(10f));
             minus.addActionListener((ActionEvent e) -> zoomSlider.setValue(zoomSlider.getValue() - 25));
-            this.scrollView.setWheelScrollingEnabled(true);
+            this.scrollView.setWheelScrollingEnabled(false);
 
             zoomSlider.setPreferredSize(new Dimension(160, 30));
 

--- a/src/main/java/edu/rpi/legup/ui/HomePanel.java
+++ b/src/main/java/edu/rpi/legup/ui/HomePanel.java
@@ -41,6 +41,9 @@ public class HomePanel extends LegupPanel {
         @Override
         public void actionPerformed(ActionEvent e) {
             Object[] items = legupUI.getPuzzleEditor().promptPuzzle();
+            if (items == null) {
+                return;
+            }
             String fileName = (String) items[0];
             File puzzleFile = (File) items[1];
             legupUI.displayPanel(2);

--- a/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
+++ b/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
@@ -29,6 +29,8 @@ import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 
+import static java.lang.System.exit;
+
 public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
 
     private final static Logger LOGGER = LogManager.getLogger(PuzzleEditorPanel.class.getName());
@@ -110,8 +112,10 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
         // file>save
         JMenuItem savePuzzle = new JMenuItem("Save");
         savePuzzle.addActionListener((ActionEvent) -> savePuzzle());
+        JMenuItem close = new JMenuItem("Close Editor");
+        close.addActionListener((ActionEvent) -> this.legupUI.displayPanel(0));
         JMenuItem exit = new JMenuItem("Exit");
-        exit.addActionListener((ActionEvent) -> this.legupUI.displayPanel(0));
+        exit.addActionListener((ActionEvent) -> System.exit(0));
         if (os.equals("mac")) {
             exit.setAccelerator(KeyStroke.getKeyStroke('Q', Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         }
@@ -120,6 +124,7 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
         }
         menus[0].add(newPuzzle);
         menus[0].add(savePuzzle);
+        menus[0].add(close);
         menus[0].add(exit);
 
         // EDIT

--- a/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
+++ b/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
@@ -255,6 +255,9 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
             fileName = fileDialog.getDirectory() + File.separator + fileDialog.getFile();
             puzzleFile = new File(fileName);
         }
+        else {
+            return null;
+        }
 
         return new Object[]{fileName, puzzleFile};
     }

--- a/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
+++ b/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
@@ -4,11 +4,14 @@ import edu.rpi.legup.app.GameBoardFacade;
 import edu.rpi.legup.app.LegupPreferences;
 import edu.rpi.legup.controller.BoardController;
 import edu.rpi.legup.controller.EditorElementController;
-import edu.rpi.legup.controller.ElementController;
 import edu.rpi.legup.history.ICommand;
 import edu.rpi.legup.history.IHistoryListener;
 import edu.rpi.legup.model.Puzzle;
 import edu.rpi.legup.model.PuzzleExporter;
+import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.treetent.TreeTentBoard;
+import edu.rpi.legup.puzzle.treetent.TreeTentCell;
+import edu.rpi.legup.puzzle.treetent.TreeTentType;
 import edu.rpi.legup.save.ExportFileException;
 import edu.rpi.legup.save.InvalidFileFormatException;
 import edu.rpi.legup.ui.boardview.BoardView;
@@ -23,6 +26,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.io.File;
 import java.net.URL;
+import java.util.List;
+import java.util.Objects;
 
 public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
 
@@ -355,6 +360,17 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
             return;
         }
 
+        //  for TreeTent, need to check validity before saving
+        if (Objects.equals(puzzle.getName(), "TreeTent")) {
+            if (!check_validity(puzzle)) {
+                int input = JOptionPane.showConfirmDialog(null, "The puzzle you edited is not " +
+                        "valid, would you still like to save? ");
+                if (input != 0) {
+                    return;
+                }
+            }
+        }
+
         if (fileDialog == null) {
             fileDialog = new FileDialog(this.frame);
         }
@@ -388,6 +404,25 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
                 e.printStackTrace();
             }
         }
+    }
+
+    /**
+     * @param puzzle
+     * @return if it is valid
+     * TreeTent puzzle must have same number of clues as the dimension size
+     */
+    private boolean check_validity(Puzzle puzzle) {
+        TreeTentBoard b = (TreeTentBoard) puzzle.getBoardView().getBoard();
+        List<PuzzleElement> elements = b.getPuzzleElements();
+        int puzzleElementCount = 0;
+        for (PuzzleElement element : elements) {
+            TreeTentCell c = (TreeTentCell) element;
+            if (c.getType() != TreeTentType.UNKNOWN) {
+                puzzleElementCount++;
+            }
+        }
+        int dim = b.getHeight();
+        return puzzleElementCount == dim;
     }
 
     public DynamicView getDynamicBoardView() {

--- a/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
+++ b/src/main/java/edu/rpi/legup/ui/PuzzleEditorPanel.java
@@ -362,7 +362,7 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
 
         //  for TreeTent, need to check validity before saving
         if (Objects.equals(puzzle.getName(), "TreeTent")) {
-            if (!check_validity(puzzle)) {
+            if (!puzzle.checkValidity()) {
                 int input = JOptionPane.showConfirmDialog(null, "The puzzle you edited is not " +
                         "valid, would you still like to save? ");
                 if (input != 0) {
@@ -406,24 +406,7 @@ public class PuzzleEditorPanel extends LegupPanel implements IHistoryListener {
         }
     }
 
-    /**
-     * @param puzzle
-     * @return if it is valid
-     * TreeTent puzzle must have same number of clues as the dimension size
-     */
-    private boolean check_validity(Puzzle puzzle) {
-        TreeTentBoard b = (TreeTentBoard) puzzle.getBoardView().getBoard();
-        List<PuzzleElement> elements = b.getPuzzleElements();
-        int puzzleElementCount = 0;
-        for (PuzzleElement element : elements) {
-            TreeTentCell c = (TreeTentCell) element;
-            if (c.getType() != TreeTentType.UNKNOWN) {
-                puzzleElementCount++;
-            }
-        }
-        int dim = b.getHeight();
-        return puzzleElementCount == dim;
-    }
+
 
     public DynamicView getDynamicBoardView() {
         return dynamicBoardView;


### PR DESCRIPTION
## Description

Add verification of the board before saving a puzzle file from the puzzle editor for TreeTent. Check that the number of clues must be equal to the dimension. 

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes #267 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
