### PR TITLE
Moved text below icon for search panel

### DIFF
--- a/src/main/java/edu/rpi/legup/ui/ProofEditorPanel.java
+++ b/src/main/java/edu/rpi/legup/ui/ProofEditorPanel.java
@@ -737,8 +737,9 @@ public class ProofEditorPanel extends LegupPanel implements IHistoryListener {
         ruleFrame.getDirectRulePanel().setRules(puzzle.getDirectRules());
         ruleFrame.getCasePanel().setRules(puzzle.getCaseRules());
         ruleFrame.getContradictionPanel().setRules(puzzle.getContradictionRules());
-        //ruleFrame.getSearchPanel().setRules(puzzle.getContradictionRules());
         ruleFrame.getSearchPanel().setSearchBar(puzzle);
+//        ruleFrame.getSearchPanel().setRules(puzzle.getBasicRules());
+
 
         toolBarButtons[ToolbarName.CHECK.ordinal()].setEnabled(true);
 //        toolBarButtons[ToolbarName.SAVE.ordinal()].setEnabled(true);

--- a/src/main/java/edu/rpi/legup/ui/proofeditorui/rulesview/RuleFrame.java
+++ b/src/main/java/edu/rpi/legup/ui/proofeditorui/rulesview/RuleFrame.java
@@ -93,7 +93,6 @@ public class RuleFrame extends JPanel {
         DirectRulePanel.setSelectionByRule(rule);
         casePanel.setSelectionByRule(rule);
         contradictionPanel.setSelectionByRule(rule);
-
     }
 
     /**
@@ -139,7 +138,6 @@ public class RuleFrame extends JPanel {
         DirectRulePanel.setRules(puzzle.getDirectRules());
         contradictionPanel.setRules(puzzle.getContradictionRules());
         casePanel.setRules(puzzle.getCaseRules());
-
     }
 
     /**

--- a/src/main/java/edu/rpi/legup/ui/proofeditorui/rulesview/RulePanel.java
+++ b/src/main/java/edu/rpi/legup/ui/proofeditorui/rulesview/RulePanel.java
@@ -102,6 +102,10 @@ public abstract class RulePanel extends JPanel {
                     ruleButtons[0] = new RuleButton(rule);
                     ruleFrame.getButtonGroup().add(ruleButtons[0]);
 
+                    ruleButtons[0].setPreferredSize(new Dimension(150,150));// adjust the size of each RuleButton
+                    ruleButtons[0].setHorizontalTextPosition(JButton.CENTER);
+                    ruleButtons[0].setVerticalTextPosition(JButton.BOTTOM);
+
                     ruleButtons[0].setToolTipText(rule.getRuleName() + ": " + rule.getDescription());
                     ruleButtons[0].addActionListener(ruleFrame.getController());
                     add(ruleButtons[0]);
@@ -113,6 +117,10 @@ public abstract class RulePanel extends JPanel {
                     ruleButtons[similarfound] = new RuleButton(rule);
                     ruleFrame.getButtonGroup().add(ruleButtons[similarfound]);
 
+                    ruleButtons[similarfound].setPreferredSize(new Dimension(150,150));// adjust the size of each RuleButton
+                    ruleButtons[similarfound].setHorizontalTextPosition(JButton.CENTER);
+                    ruleButtons[similarfound].setVerticalTextPosition(JButton.BOTTOM);
+
                     ruleButtons[similarfound].setToolTipText(rule.getRuleName() + ": " + rule.getDescription());
                     ruleButtons[similarfound].addActionListener(ruleFrame.getController());
                     add(ruleButtons[similarfound]);
@@ -122,6 +130,10 @@ public abstract class RulePanel extends JPanel {
                 else if((ruleName.charAt(0)) == (rule.getRuleName().toUpperCase()).charAt(0)){
                     ruleButtons[similarfound] = new RuleButton(rule);
                     ruleFrame.getButtonGroup().add(ruleButtons[similarfound]);
+
+                    ruleButtons[similarfound].setPreferredSize(new Dimension(150,150));// adjust the size of each RuleButton
+                    ruleButtons[similarfound].setHorizontalTextPosition(JButton.CENTER);
+                    ruleButtons[similarfound].setVerticalTextPosition(JButton.BOTTOM);
 
                     ruleButtons[similarfound].setToolTipText(rule.getRuleName() + ": " + rule.getDescription());
                     ruleButtons[similarfound].addActionListener(ruleFrame.getController());


### PR DESCRIPTION
## Description
When searching for rules in the search panel, the buttons sizes used to not be regulated and the text was on the side making the panel look disorganized. This was because in the searchForRule function, when buttons were created from the found rules there was no changes to the preferred size of the button. I added this code to make the preferred size 150 x 150 and I also moved the text to be at the bottom of the button and centered, like in the other panels. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
In the searchForRule function, when similar rules were found to the search result and a new button was created; I added code to change the preferred size using setPreferredSize, and I changed the positioning of the text using setHorizontalTextPosition and setVerticalTextPosition.

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes #432 

## Type of change

- [ -] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [ -] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ -] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
