### PR TITLE
Fixed Nurikabe Corner Bug

### DIFF
--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CornerBlackDirectRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CornerBlackDirectRule.java
@@ -46,7 +46,7 @@ public class CornerBlackDirectRule extends DirectRule {
         for (int i = -1; i < 2; i += 2) {
             for (int j = -1; j < 2; j += 2) {
                 // If the corner does not exist, skip the corner
-                if (!(cellLocation.x + i >= 0 && cellLocation.x + i < board.getWidth() && cellLocation.y + j >= 0 && cellLocation.x + i < board.getHeight())) {
+                if (!(cellLocation.x + i >= 0 && cellLocation.x + i < board.getWidth() && cellLocation.y + j >= 0 && cellLocation.y + j < board.getHeight())) {
                     continue;
                 }
 

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CornerBlackDirectRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/CornerBlackDirectRule.java
@@ -46,7 +46,7 @@ public class CornerBlackDirectRule extends DirectRule {
         for (int i = -1; i < 2; i += 2) {
             for (int j = -1; j < 2; j += 2) {
                 // If the corner does not exist, skip the corner
-                if (!(cellLocation.x + i >= 0 && cellLocation.x + i < board.getWidth() && cellLocation.y + j >= 0 && cellLocation.y + j < board.getHeight())) {
+                if (!(cellLocation.x + i >= 0 && cellLocation.x + i < board.getWidth() && cellLocation.y + j >= 0 && cellLocation.x + i < board.getHeight())) {
                     continue;
                 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #447, changed bounds check (likely a typo)

<!-- If your pull request is not related to a particular issue, delete the statement below. -->

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Tested on Nurikabe 5x5 Normal 7587733 (original issue) and on Nurikabe Normal 7x7 7958242 bottom left corner. I selected the bottom left corner, clicked until the tile was black, selected "Corners Black" and successfully received the appropriate red triangle error. I went one step back in the tree and selected "Can't Reach Cell" which gave the appropriate success tree.

## Checklist:

- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
