### PR TITLE
489 treetent puzzle axis

### DIFF
--- a/puzzles files/treetent/12x12 TreeTent Easy/061177
+++ b/puzzles files/treetent/12x12 TreeTent Easy/061177
@@ -47,18 +47,18 @@
                 <clue index="L" value="1"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="4"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="3"/>
-                <clue index="6" value="2"/>
-                <clue index="7" value="3"/>
-                <clue index="8" value="0"/>
-                <clue index="9" value="4"/>
-                <clue index="10" value="1"/>
-                <clue index="11" value="5"/>
-                <clue index="12" value="1"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Easy/198217
+++ b/puzzles files/treetent/12x12 TreeTent Easy/198217
@@ -46,18 +46,18 @@
                 <clue index="L" value="2"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="4"/>
-                <clue index="2" value="1"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
                 <clue index="3" value="3"/>
-                <clue index="4" value="2"/>
-                <clue index="5" value="4"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="3"/>
-                <clue index="8" value="1"/>
-                <clue index="9" value="2"/>
-                <clue index="10" value="3"/>
-                <clue index="11" value="2"/>
-                <clue index="12" value="2"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Easy/255410
+++ b/puzzles files/treetent/12x12 TreeTent Easy/255410
@@ -47,18 +47,18 @@
                 <clue index="L" value="3"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
                 <clue index="3" value="3"/>
-                <clue index="4" value="0"/>
+                <clue index="4" value="4"/>
                 <clue index="5" value="5"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="3"/>
-                <clue index="9" value="0"/>
-                <clue index="10" value="5"/>
-                <clue index="11" value="1"/>
-                <clue index="12" value="3"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Easy/790635
+++ b/puzzles files/treetent/12x12 TreeTent Easy/790635
@@ -47,18 +47,18 @@
                 <clue index="L" value="3"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
                 <clue index="3" value="3"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="4"/>
-                <clue index="6" value="0"/>
-                <clue index="7" value="3"/>
-                <clue index="8" value="2"/>
-                <clue index="9" value="3"/>
-                <clue index="10" value="2"/>
-                <clue index="11" value="2"/>
-                <clue index="12" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Easy/805457
+++ b/puzzles files/treetent/12x12 TreeTent Easy/805457
@@ -47,18 +47,18 @@
                 <clue index="L" value="1"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
-                <clue index="3" value="4"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="3"/>
-                <clue index="6" value="2"/>
-                <clue index="7" value="3"/>
-                <clue index="8" value="2"/>
-                <clue index="9" value="2"/>
-                <clue index="10" value="2"/>
-                <clue index="11" value="3"/>
-                <clue index="12" value="1"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Medium/154674
+++ b/puzzles files/treetent/12x12 TreeTent Medium/154674
@@ -46,18 +46,18 @@
                 <clue index="L" value="4"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="2"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
                 <clue index="3" value="3"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="3"/>
-                <clue index="6" value="2"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="4"/>
-                <clue index="9" value="1"/>
-                <clue index="10" value="3"/>
-                <clue index="11" value="1"/>
-                <clue index="12" value="4"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Medium/330689
+++ b/puzzles files/treetent/12x12 TreeTent Medium/330689
@@ -47,18 +47,18 @@
                 <clue index="L" value="4"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="5"/>
-                <clue index="2" value="0"/>
-                <clue index="3" value="4"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="3"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="4"/>
-                <clue index="8" value="1"/>
-                <clue index="9" value="3"/>
-                <clue index="10" value="1"/>
-                <clue index="11" value="1"/>
-                <clue index="12" value="4"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Medium/538746
+++ b/puzzles files/treetent/12x12 TreeTent Medium/538746
@@ -48,17 +48,17 @@
             </axis>
             <axis side="south">
                 <clue index="1" value="1"/>
-                <clue index="2" value="4"/>
-                <clue index="3" value="1"/>
-                <clue index="4" value="2"/>
-                <clue index="5" value="4"/>
-                <clue index="6" value="2"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="3"/>
-                <clue index="9" value="0"/>
-                <clue index="10" value="4"/>
-                <clue index="11" value="2"/>
-                <clue index="12" value="3"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Medium/579921
+++ b/puzzles files/treetent/12x12 TreeTent Medium/579921
@@ -47,18 +47,18 @@
                 <clue index="L" value="2"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="3"/>
-                <clue index="5" value="3"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="3"/>
-                <clue index="8" value="3"/>
-                <clue index="9" value="2"/>
-                <clue index="10" value="2"/>
-                <clue index="11" value="2"/>
-                <clue index="12" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/12x12 TreeTent Medium/723664
+++ b/puzzles files/treetent/12x12 TreeTent Medium/723664
@@ -47,18 +47,18 @@
                 <clue index="L" value="3"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="2"/>
-                <clue index="5" value="3"/>
-                <clue index="6" value="2"/>
-                <clue index="7" value="1"/>
-                <clue index="8" value="3"/>
-                <clue index="9" value="1"/>
-                <clue index="10" value="4"/>
-                <clue index="11" value="2"/>
-                <clue index="12" value="3"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
+                <clue index="11" value="11"/>
+                <clue index="12" value="12"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Easy/13547135
+++ b/puzzles files/treetent/8x8 TreeTent Easy/13547135
@@ -27,14 +27,14 @@
                 <clue index="H" value="1"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="2"/>
-                <clue index="2" value="1"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="3"/>
-                <clue index="6" value="0"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="1"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Easy/1646651
+++ b/puzzles files/treetent/8x8 TreeTent Easy/1646651
@@ -27,14 +27,14 @@
                 <clue index="H" value="2"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
-                <clue index="2" value="0"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="2"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="1"/>
-                <clue index="8" value="2"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Easy/1789167
+++ b/puzzles files/treetent/8x8 TreeTent Easy/1789167
@@ -29,12 +29,12 @@
             <axis side="south">
                 <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
-                <clue index="3" value="1"/>
-                <clue index="4" value="2"/>
-                <clue index="5" value="2"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="1"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Easy/32518510
+++ b/puzzles files/treetent/8x8 TreeTent Easy/32518510
@@ -27,14 +27,14 @@
                 <clue index="H" value="3"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
-                <clue index="2" value="0"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
                 <clue index="3" value="3"/>
-                <clue index="4" value="0"/>
-                <clue index="5" value="1"/>
-                <clue index="6" value="2"/>
-                <clue index="7" value="0"/>
-                <clue index="8" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Easy/4614656
+++ b/puzzles files/treetent/8x8 TreeTent Easy/4614656
@@ -27,14 +27,14 @@
                 <clue index="H" value="3"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="2"/>
-                <clue index="2" value="1"/>
-                <clue index="3" value="1"/>
-                <clue index="4" value="2"/>
-                <clue index="5" value="0"/>
-                <clue index="6" value="3"/>
-                <clue index="7" value="0"/>
-                <clue index="8" value="3"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Medium/351654
+++ b/puzzles files/treetent/8x8 TreeTent Medium/351654
@@ -27,14 +27,14 @@
                 <clue index="H" value="1"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="2"/>
-                <clue index="2" value="0"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
                 <clue index="3" value="3"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="2"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="1"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Medium/35496
+++ b/puzzles files/treetent/8x8 TreeTent Medium/35496
@@ -26,14 +26,14 @@
                 <clue index="H" value="1"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="3"/>
-                <clue index="2" value="1"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="0"/>
-                <clue index="5" value="2"/>
-                <clue index="6" value="0"/>
-                <clue index="7" value="3"/>
-                <clue index="8" value="1"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Medium/4656816
+++ b/puzzles files/treetent/8x8 TreeTent Medium/4656816
@@ -27,14 +27,14 @@
                 <clue index="H" value="1"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="2"/>
-                <clue index="2" value="1"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="2"/>
-                <clue index="5" value="2"/>
-                <clue index="6" value="0"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="1"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Medium/6549871
+++ b/puzzles files/treetent/8x8 TreeTent Medium/6549871
@@ -27,14 +27,14 @@
                 <clue index="H" value="1"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="2"/>
+                <clue index="1" value="1"/>
                 <clue index="2" value="2"/>
-                <clue index="3" value="1"/>
-                <clue index="4" value="2"/>
-                <clue index="5" value="1"/>
-                <clue index="6" value="1"/>
-                <clue index="7" value="2"/>
-                <clue index="8" value="1"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/puzzles files/treetent/8x8 TreeTent Medium/989496
+++ b/puzzles files/treetent/8x8 TreeTent Medium/989496
@@ -27,14 +27,14 @@
                 <clue index="H" value="3"/>
             </axis>
             <axis side="south">
-                <clue index="1" value="2"/>
-                <clue index="2" value="1"/>
-                <clue index="3" value="1"/>
-                <clue index="4" value="1"/>
-                <clue index="5" value="2"/>
-                <clue index="6" value="2"/>
-                <clue index="7" value="0"/>
-                <clue index="8" value="3"/>
+                <clue index="1" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
             </axis>
         </board>
     </puzzle>

--- a/src/main/resources/edu/rpi/legup/puzzlefiles/treetent/TreeTenttest
+++ b/src/main/resources/edu/rpi/legup/puzzlefiles/treetent/TreeTenttest
@@ -33,15 +33,15 @@
             </axis>
             <axis side="south">
                 <clue index="1" value="1"/>
-                <clue index="2" value="1"/>
-                <clue index="3" value="2"/>
-                <clue index="4" value="3"/>
-                <clue index="5" value="0"/>
-                <clue index="6" value="3"/>
-                <clue index="7" value="0"/>
-                <clue index="8" value="3"/>
-                <clue index="9" value="1"/>
-                <clue index="10" value="1"/>
+                <clue index="2" value="2"/>
+                <clue index="3" value="3"/>
+                <clue index="4" value="4"/>
+                <clue index="5" value="5"/>
+                <clue index="6" value="6"/>
+                <clue index="7" value="7"/>
+                <clue index="8" value="8"/>
+                <clue index="9" value="9"/>
+                <clue index="10" value="10"/>
             </axis>
             <lines>
                 <line x1="1" x2="2" y1="1" y2="2"/>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In a treetent puzzle, only the numbers on the right side should indicate how many tents are in the respective row. Currently, the same numbers are also used in the lower side. This PR removes the confusion.

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes #489 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
