### PR TITLE
Short Truth Table Broken Importer Fixes

### DIFF
--- a/bin/main/edu/rpi/legup/puzzle/skyscrapers/rules/TODO.md
+++ b/bin/main/edu/rpi/legup/puzzle/skyscrapers/rules/TODO.md
@@ -11,7 +11,7 @@ spreadsheet : https://docs.google.com/spreadsheets/d/1l7aUZtavtysM8dtGnaEIXhBKMR
  4. Refactoring:
     - document utility functions in the reference sheet, COMMENTS!
     - review and identify dead code
-    - remove all these damn print statments (commented ones too if they aren't useful)
+    - remove all these damn print statements (commented ones too if they aren't useful)
     - Edit to allow blank clues
     - Display flags somewhere
  5. Flags

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableBoard.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableBoard.java
@@ -4,6 +4,7 @@ import edu.rpi.legup.model.gameboard.Board;
 import edu.rpi.legup.model.gameboard.GridBoard;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
 
+import edu.rpi.legup.puzzle.lightup.LightUpCell;
 import edu.rpi.legup.puzzle.shorttruthtable.*;
 
 import java.awt.*;
@@ -40,6 +41,11 @@ public class ShortTruthTableBoard extends GridBoard {
 
     public ShortTruthTableCell getCellFromElement(PuzzleElement element) {
         return (ShortTruthTableCell) getPuzzleElement(element);
+    }
+
+    @Override
+    public ShortTruthTableCell getCell(int x, int y) {
+        return (ShortTruthTableCell) super.getCell(x, y);
     }
 
 
@@ -93,6 +99,17 @@ public class ShortTruthTableBoard extends GridBoard {
 //        cell.setType(cellElement.getType());
 //    }
 
+    @Override
+    public void notifyChange(PuzzleElement puzzleElement) {
+        ShortTruthTableCell cell = (ShortTruthTableCell) puzzleElement;
+        int r = cell.getY();
+        int c = cell.getX();
+        if (r % 2 == 0 && c < statements[r / 2].getLength()) {
+            statements[r / 2] = statements[r / 2].replace(c, cell);
+            setCell(c, r, statements[r / 2].getCell(c));
+        }
+        super.notifyChange(cell);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableImporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableImporter.java
@@ -22,7 +22,7 @@ class ShortTruthTableImporter extends PuzzleImporter {
 
 
     /**
-     * Parse a string into all te cells, the y position of the statement is passed so the y position can be set
+     * Parse a string into all the cells, the y position of the statement is passed so the y position can be set
      *
      * @param statement
      * @param y
@@ -54,7 +54,7 @@ class ShortTruthTableImporter extends PuzzleImporter {
      * @param statements    returns all the statements
      * @return the length, in chars, of the longest statement
      */
-    private int parseAllStatmentsAndCells(final NodeList statementData,
+    private int parseAllStatementsAndCells(final NodeList statementData,
                                           List<List<ShortTruthTableCell>> allCells,
                                           List<ShortTruthTableStatement> statements) throws InvalidFileFormatException {
 
@@ -167,7 +167,7 @@ class ShortTruthTableImporter extends PuzzleImporter {
                 //get the cell at this location; or create a not_in_play one if necessary
                 ShortTruthTableCell cell = null;
 
-                //for a cell to exist at (x, y), it must be a valid row and within the statment length
+                //for a cell to exist at (x, y), it must be a valid row and within the statement length
                 if (y % 2 == 0 && x < statements.get(statementIndex).getLength()) {
                     cell = allCells.get(statementIndex).get(x);
                     System.out.println("Importer: check cell statement ref: " + cell.getStatementReference());
@@ -195,7 +195,7 @@ class ShortTruthTableImporter extends PuzzleImporter {
                                List<ShortTruthTableStatement> statements) throws InvalidFileFormatException {
 
 
-        //if it is normal, set all predicats to true and the conclusion to false
+        //if it is normal, set all predicates to true and the conclusion to false
         if (dataElement.getAttribute("normal").equalsIgnoreCase("true")) {
             //set all predicates to true (all but the last one)
             for (int i = 0; i < statements.size() - 1; i++) {
@@ -264,7 +264,7 @@ class ShortTruthTableImporter extends PuzzleImporter {
 
 
             //Parse the data
-            int maxStatementLength = parseAllStatmentsAndCells(statementData, allCells, statements);
+            int maxStatementLength = parseAllStatementsAndCells(statementData, allCells, statements);
 
             //generate the board
             ShortTruthTableBoard sttBoard = generateBoard(allCells, statements, maxStatementLength);

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
@@ -295,4 +295,19 @@ public class ShortTruthTableStatement extends PuzzleElement<String> {
         return statementCopy;
     }
 
+    public ShortTruthTableStatement replace(int column, ShortTruthTableCell cell) {
+        //copy all the cells (replacing one)
+        List<ShortTruthTableCell> cellsCopy = new ArrayList<>();
+        for (ShortTruthTableCell c : cells) {
+            if (c.getX() == column) {
+                cellsCopy.add(cell);
+            } else {
+                cellsCopy.add(c.copy());
+            }
+        }
+        //make a copy of the statement with all the copied cells
+        //return the new statement
+        return new ShortTruthTableStatement(stringRep, cellsCopy);
+    }
+
 }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
@@ -95,7 +95,7 @@ public class ShortTruthTableStatement extends PuzzleElement<String> {
                 if (c == ')') openParenCount--;
             }
 
-            //if the first paren has been closed and it is not the end of the string,
+            //if the first paren has been closed, and it is not the end of the string,
             //then there is no whole statement parens to remove
             if (openParenCount == 0 && i != statement.length() - 1) {
                 return statement;
@@ -164,7 +164,7 @@ public class ShortTruthTableStatement extends PuzzleElement<String> {
                 if (c == ')') openParenCount--;
             }
 
-            //if the first paren has been closed and it is not the end of the string,
+            //if the first paren has been closed, and it is not the end of the string,
             //then there is no whole statement parens to remove
             if (openParenCount == 0 && i != cells.size() - 1) {
                 return;
@@ -241,7 +241,7 @@ public class ShortTruthTableStatement extends PuzzleElement<String> {
      * Returns an array of three elements where [0] is the left
      * statement type, [1] is this statement type, and [2] is the
      * right statement type. null means either the statement doesn't
-     * exist or is is an unknown value.
+     * exist or is an unknown value.
      *
      * @return the assigned values to this statement and its sub-statements
      */
@@ -285,14 +285,13 @@ public class ShortTruthTableStatement extends PuzzleElement<String> {
 
     public ShortTruthTableStatement copy() {
         //copy all the cells
-        List<ShortTruthTableCell> cellsCopy = new ArrayList<ShortTruthTableCell>();
+        List<ShortTruthTableCell> cellsCopy = new ArrayList<>();
         for (ShortTruthTableCell c : cells) {
             cellsCopy.add(c.copy());
         }
         //make a copy of the statement with all the copied cells
-        ShortTruthTableStatement statementCopy = new ShortTruthTableStatement(stringRep, cellsCopy);
         //return the new statement
-        return statementCopy;
+        return new ShortTruthTableStatement(stringRep, cellsCopy);
     }
 
     public ShortTruthTableStatement replace(int column, ShortTruthTableCell cell) {

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
@@ -301,7 +301,8 @@ public class ShortTruthTableStatement extends PuzzleElement<String> {
         for (ShortTruthTableCell c : cells) {
             if (c.getX() == column) {
                 cellsCopy.add(cell);
-            } else {
+            }
+            else {
                 cellsCopy.add(c.copy());
             }
         }

--- a/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
+++ b/src/main/java/edu/rpi/legup/puzzle/shorttruthtable/ShortTruthTableStatement.java
@@ -302,7 +302,7 @@ public class ShortTruthTableStatement extends PuzzleElement<String> {
                 cellsCopy.add(cell);
             }
             else {
-                cellsCopy.add(c.copy());
+                cellsCopy.add(c);
             }
         }
         //make a copy of the statement with all the copied cells

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/TODO.md
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/rules/TODO.md
@@ -11,7 +11,7 @@ spreadsheet : https://docs.google.com/spreadsheets/d/1l7aUZtavtysM8dtGnaEIXhBKMR
 4. Refactoring:
     - document utility functions in the reference sheet, COMMENTS!
     - review and identify dead code
-    - remove all these damn print statments (commented ones too if they aren't useful)
+    - remove all these damn print statements (commented ones too if they aren't useful)
     - Edit to allow blank clues
     - Display flags somewhere
 5. Flags


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Short truth table's importer has been bugged seemingly from it's creation, causing some valid proofs to appear invalid after reopening them and causing broken proofs after attempting to alter a reopened proof. The problem was that the statements had to change whenever the cells would change, but one function used in the importer didn't do that. The statements are immutable (since they're PuzzleElements), so any change to a cell requires the whole statement to be rewritten.

My changes keep the statement list updated along with the cells on the board (specificaly for notifyChange).

In the future, the ShortTruthTableStatement class should not be an extension of PuzzleElement<String> and should instead be a sort of look-up-table for cells on the board. For now, rewritting the statements should fix the importer bugs.

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes #138
Closes #416 
Closes #465

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

I solved, saved, and reopened both `Heuveln_01.xml` and `Heuveln_02.xml`.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
