### PR TITLE
No Number Contradiction Bug Fix

### DIFF
--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/NurikabeUtilities.java
@@ -241,4 +241,67 @@ public class NurikabeUtilities {
         }
         return whiteRegionMap;
     }
+
+    /**
+     * Gets all the non-black cells connected to the given cell
+     *
+     * @param board nurikabe board
+     * @param center nurikabe cell
+     * @return a set of all white/numbered cells in the region
+     */
+    public static Set<NurikabeCell> getSurroundedRegionOf(NurikabeBoard board, NurikabeCell center) {
+        int width = board.getWidth();
+        int height = board.getHeight();
+
+        // Mark all the vertices as not visited(By default
+        // set as false)
+        Set<NurikabeCell> visited = new HashSet<>();
+
+        // Create a queue for BFS
+        LinkedList<NurikabeCell> queue = new LinkedList<>();
+
+        // Mark the current node as visited and enqueue it
+        visited.add(center);
+        queue.add(center);
+
+        // Set of cells in the current region
+        Set<NurikabeCell> connected = new HashSet<>();
+
+        while (queue.size() != 0) {
+            // Dequeue a vertex from queue and print it
+            // s is the source node in the graph
+            NurikabeCell s = queue.poll();
+            System.out.print(s + " ");
+
+            // Make a set of all adjacent squares
+            Set<NurikabeCell> adj = new HashSet<>();
+
+            Point loc = s.getLocation();
+            // First check if the side is on the board
+            if (loc.x >= 1) {
+                adj.add(board.getCell(loc.x - 1, loc.y));
+            }
+            if (loc.x < width - 1) {
+                adj.add(board.getCell(loc.x + 1, loc.y));
+            }
+            if (loc.y >= 1) {
+                adj.add(board.getCell(loc.x, loc.y - 1));
+            }
+            if (loc.y < height - 1) {
+                adj.add(board.getCell(loc.x, loc.y + 1));
+            }
+            // Get all adjacent vertices of the dequeued vertex s
+            // If a adjacent has not been visited, then mark it
+            // visited and enqueue it
+            for (NurikabeCell n : adj) {
+                if (!visited.contains(n) && n.getType() != NurikabeType.BLACK) {
+                    connected.add(n);
+                    visited.add(n);
+                    queue.add(n);
+                }
+            }
+        }
+
+        return connected;
+    }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/NoNumberContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/nurikabe/rules/NoNumberContradictionRule.java
@@ -42,19 +42,17 @@ public class NoNumberContradictionRule extends ContradictionRule {
             return super.getInvalidUseOfRuleMessage() + ": " + this.INVALID_USE_MESSAGE;
         }
 
-//        If the transition creates a room of white cells with no number, a contradiction occurs.
-        DisjointSets<NurikabeCell> anotherRegion = NurikabeUtilities.getPossibleWhiteRegions(nurikabeBoard);
-        List<Set<NurikabeCell>> allsets = anotherRegion.getAllSets();
-        for (Set<NurikabeCell> s : allsets) {
-            boolean numberExists = false;
-            for (NurikabeCell c : s) {
-                if (c.getType() == NurikabeType.NUMBER) {
-                    numberExists = true;
-                }
+        Set<NurikabeCell> region = NurikabeUtilities.getSurroundedRegionOf(nurikabeBoard, cell);
+
+        boolean numberExists = false;
+        for (NurikabeCell c : region) {
+            if (c.getType() == NurikabeType.NUMBER) {
+                numberExists = true;
+                break;
             }
-            if (!numberExists) {
-                return null;
-            }
+        }
+        if (!numberExists) {
+            return null;
         }
         return super.getNoContradictionMessage() + ": " + this.NO_CONTRADICTION_MESSAGE;
     }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This is a change to the behavior of `NoNumberContradictionRule`, and therefore affects `FillinBlackDirectRule`.

The original code had two problems. First, it tried to check every cell on the board for the rule for each cell (which does n times as many checks as required). Second, when checking for other "possible" white regions, the regions with no white cells were included, bypassing the original check of the cell in question.

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes #554 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

I solved puzzle 1795638 (under 5x5 Normal) by using as much of the contradiction and corresponding direct rule as I could.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
