### PR TITLE
Null board when creating new puzzle file bug fix

### DIFF
--- a/src/main/java/edu/rpi/legup/puzzle/battleship/BattleshipExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/battleship/BattleshipExporter.java
@@ -2,6 +2,7 @@ package edu.rpi.legup.puzzle.battleship;
 
 import edu.rpi.legup.model.PuzzleExporter;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableBoard;
 import org.w3c.dom.Document;
 
 public class BattleshipExporter extends PuzzleExporter {
@@ -18,7 +19,13 @@ public class BattleshipExporter extends PuzzleExporter {
      */
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        BattleshipBoard board = (BattleshipBoard) puzzle.getTree().getRootNode().getBoard();
+        BattleshipBoard board;
+        if (puzzle.getTree() != null) {
+            board = (BattleshipBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (BattleshipBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("width", String.valueOf(board.getWidth()));

--- a/src/main/java/edu/rpi/legup/puzzle/fillapix/FillapixExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/fillapix/FillapixExporter.java
@@ -2,6 +2,7 @@ package edu.rpi.legup.puzzle.fillapix;
 
 import edu.rpi.legup.model.PuzzleExporter;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableBoard;
 import org.w3c.dom.Document;
 
 public class FillapixExporter extends PuzzleExporter {
@@ -12,7 +13,13 @@ public class FillapixExporter extends PuzzleExporter {
 
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        FillapixBoard board = (FillapixBoard) puzzle.getTree().getRootNode().getBoard();
+        FillapixBoard board;
+        if (puzzle.getTree() != null) {
+            board = (FillapixBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (FillapixBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("width", String.valueOf(board.getWidth()));

--- a/src/main/java/edu/rpi/legup/puzzle/heyawake/HeyawakeExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/heyawake/HeyawakeExporter.java
@@ -2,6 +2,7 @@ package edu.rpi.legup.puzzle.heyawake;
 
 import edu.rpi.legup.model.PuzzleExporter;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableBoard;
 import org.w3c.dom.Document;
 
 public class HeyawakeExporter extends PuzzleExporter {
@@ -12,7 +13,13 @@ public class HeyawakeExporter extends PuzzleExporter {
 
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        HeyawakeBoard board = (HeyawakeBoard) puzzle.getTree().getRootNode().getBoard();
+        HeyawakeBoard board;
+        if (puzzle.getTree() != null) {
+            board = (HeyawakeBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (HeyawakeBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("width", String.valueOf(board.getWidth()));

--- a/src/main/java/edu/rpi/legup/puzzle/lightup/LightUpExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/lightup/LightUpExporter.java
@@ -2,6 +2,7 @@ package edu.rpi.legup.puzzle.lightup;
 
 import edu.rpi.legup.model.PuzzleExporter;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableBoard;
 import org.w3c.dom.Document;
 
 public class LightUpExporter extends PuzzleExporter {
@@ -12,7 +13,13 @@ public class LightUpExporter extends PuzzleExporter {
 
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        LightUpBoard board = (LightUpBoard) puzzle.getTree().getRootNode().getBoard();
+        LightUpBoard board;
+        if (puzzle.getTree() != null) {
+            board = (LightUpBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (LightUpBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("width", String.valueOf(board.getWidth()));

--- a/src/main/java/edu/rpi/legup/puzzle/masyu/MasyuExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/masyu/MasyuExporter.java
@@ -2,6 +2,7 @@ package edu.rpi.legup.puzzle.masyu;
 
 import edu.rpi.legup.model.PuzzleExporter;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableBoard;
 import org.w3c.dom.Document;
 
 public class MasyuExporter extends PuzzleExporter {
@@ -12,7 +13,13 @@ public class MasyuExporter extends PuzzleExporter {
 
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        MasyuBoard board = (MasyuBoard) puzzle.getTree().getRootNode().getBoard();
+        MasyuBoard board;
+        if (puzzle.getTree() != null) {
+            board = (MasyuBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (MasyuBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("width", String.valueOf(board.getWidth()));

--- a/src/main/java/edu/rpi/legup/puzzle/skyscrapers/SkyscrapersExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/skyscrapers/SkyscrapersExporter.java
@@ -2,6 +2,7 @@ package edu.rpi.legup.puzzle.skyscrapers;
 
 import edu.rpi.legup.model.PuzzleExporter;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.shorttruthtable.ShortTruthTableBoard;
 import org.w3c.dom.Document;
 
 public class SkyscrapersExporter extends PuzzleExporter {
@@ -12,7 +13,13 @@ public class SkyscrapersExporter extends PuzzleExporter {
 
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        SkyscrapersBoard board = (SkyscrapersBoard) puzzle.getTree().getRootNode().getBoard();
+        SkyscrapersBoard board;
+        if (puzzle.getTree() != null) {
+            board = (SkyscrapersBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (SkyscrapersBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("width", String.valueOf(board.getWidth()));

--- a/src/main/java/edu/rpi/legup/puzzle/sudoku/SudokuExporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/sudoku/SudokuExporter.java
@@ -2,6 +2,7 @@ package edu.rpi.legup.puzzle.sudoku;
 
 import edu.rpi.legup.model.PuzzleExporter;
 import edu.rpi.legup.model.gameboard.PuzzleElement;
+import edu.rpi.legup.puzzle.skyscrapers.SkyscrapersBoard;
 import org.w3c.dom.Document;
 
 public class SudokuExporter extends PuzzleExporter {
@@ -12,7 +13,13 @@ public class SudokuExporter extends PuzzleExporter {
 
     @Override
     protected org.w3c.dom.Element createBoardElement(Document newDocument) {
-        SudokuBoard board = (SudokuBoard) puzzle.getTree().getRootNode().getBoard();
+        SudokuBoard board;
+        if (puzzle.getTree() != null) {
+            board = (SudokuBoard) puzzle.getTree().getRootNode().getBoard();
+        }
+        else {
+            board = (SudokuBoard) puzzle.getBoardView().getBoard();
+        }
 
         org.w3c.dom.Element boardElement = newDocument.createElement("board");
         boardElement.setAttribute("size", String.valueOf(board.getSize()));


### PR DESCRIPTION
## Description
Fixed a bug where attempting to save a brand new puzzle file created in LEGUP would cause an error since the length of the proof tree would be 0. This fixes that error by adding an if check to get the puzzle board an alternative way if the length of the proof tree is 0.
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<!-- If your pull request is not related to a particular issue, delete the statement below. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
