### PR TITLE
Fix treetent puzzle editor

### DIFF
--- a/src/main/java/edu/rpi/legup/model/gameboard/GridBoard.java
+++ b/src/main/java/edu/rpi/legup/model/gameboard/GridBoard.java
@@ -75,27 +75,34 @@ public class GridBoard extends Board {
                 if (m.getButton() == MouseEvent.BUTTON1) {
                     if (clue.getData() < dimension.height) {
                         clue.setData(clue.getData() + 1);
-                    } else {
+                    }
+                    else {
                         clue.setData(0);
                     }
-                } else {
+                }
+                else {
                     if (clue.getData() > 0) {
                         clue.setData(clue.getData() - 1);
-                    } else {
+                    }
+                    else {
                         clue.setData(dimension.height);
                     }
                 }
-            } else { //x == dimension.width
+            }
+            else { //x == dimension.width
                 if (m.getButton() == MouseEvent.BUTTON1) {
                     if (clue.getData() < dimension.width) {
                         clue.setData(clue.getData() + 1);
-                    } else {
+                    }
+                    else {
                         clue.setData(0);
                     }
-                } else {
+                }
+                else {
                     if (clue.getData() > 0) {
                         clue.setData(clue.getData() - 1);
-                    } else {
+                    }
+                    else {
                         clue.setData(dimension.width);
                     }
                 }

--- a/src/main/java/edu/rpi/legup/model/gameboard/GridBoard.java
+++ b/src/main/java/edu/rpi/legup/model/gameboard/GridBoard.java
@@ -71,15 +71,33 @@ public class GridBoard extends Board {
         if (this instanceof TreeTentBoard && ((y == dimension.height && 0 <= x && x < dimension.width) || (x == dimension.width && 0 <= y && y < dimension.height))) {
             TreeTentBoard treeTentBoard = ((TreeTentBoard) this);
             TreeTentClue clue = treeTentBoard.getClue(x, y);
-            if (y == dimension.height && clue.getData() < dimension.width) {
-                clue.setData(clue.getData() + 1);
-            }
-            else {
-                if (x == dimension.width && clue.getData() < dimension.height) {
-                    clue.setData(clue.getData() + 1);
+            if (y == dimension.height) {
+                if (m.getButton() == MouseEvent.BUTTON1) {
+                    if (clue.getData() < dimension.height) {
+                        clue.setData(clue.getData() + 1);
+                    } else {
+                        clue.setData(0);
+                    }
+                } else {
+                    if (clue.getData() > 0) {
+                        clue.setData(clue.getData() - 1);
+                    } else {
+                        clue.setData(dimension.height);
+                    }
                 }
-                else {
-                    clue.setData(0);
+            } else { //x == dimension.width
+                if (m.getButton() == MouseEvent.BUTTON1) {
+                    if (clue.getData() < dimension.width) {
+                        clue.setData(clue.getData() + 1);
+                    } else {
+                        clue.setData(0);
+                    }
+                } else {
+                    if (clue.getData() > 0) {
+                        clue.setData(clue.getData() - 1);
+                    } else {
+                        clue.setData(dimension.width);
+                    }
                 }
             }
         }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentCell.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentCell.java
@@ -16,15 +16,31 @@ public class TreeTentCell extends GridCell<TreeTentType> {
         return data;
     }
 
+    public int getValue() {
+        switch (data) {
+            case TREE:
+                return 1;
+            case GRASS:
+                return 2;
+            case TENT:
+                return 3;
+            default:
+                return 0;
+        }
+    }
+
     @Override
     public void setType(Element e, MouseEvent m) {
         switch (e.getElementName()) {
             case "Unknown Tile":
                 this.data = TreeTentType.UNKNOWN;
+                break;
             case "Tree Tile":
                 this.data = TreeTentType.TREE;
+                break;
             case "Grass Tile":
                 this.data = TreeTentType.GRASS;
+                break;
             case "Tent Tile":
                 this.data = TreeTentType.TENT;
         }

--- a/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentCellFactory.java
+++ b/src/main/java/edu/rpi/legup/puzzle/treetent/TreeTentCellFactory.java
@@ -83,7 +83,7 @@ public class TreeTentCellFactory extends ElementFactory {
             TreeTentCell cell = (TreeTentCell) puzzleElement;
             Point loc = cell.getLocation();
 
-            cellElement.setAttribute("value", String.valueOf(cell.getData()));
+            cellElement.setAttribute("value", String.valueOf(cell.getValue()));
             cellElement.setAttribute("x", String.valueOf(loc.x));
             cellElement.setAttribute("y", String.valueOf(loc.y));
 


### PR DESCRIPTION
## Description
Uses the code from #530 to fix the treetent puzzle editor.

Where very simple fixes. There was a switch statement missing "break"s. And the TreeTent puzzle exporter was exporting string values, while the importer expected integers.

Closes #503, #530

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Created a puzzle using the editor and successfully opened it back up.

## Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
