### PR TITLE
Short Truth Table Case Rule Test Fix

### DIFF
--- a/src/test/java/puzzles/shorttruthtable/rules/AndCaseRuleTest.java
+++ b/src/test/java/puzzles/shorttruthtable/rules/AndCaseRuleTest.java
@@ -42,7 +42,7 @@ public class AndCaseRuleTest {
         ArrayList<Board> cases = RULE.getCases(board, cell);
 
         // Make sure that the rule checks out
-        Assert.assertNotNull(RULE.checkRule(transition));
+        Assert.assertNull(RULE.checkRule(transition));
 
         // Make sure there are two branches
         Assert.assertEquals(2, cases.size());
@@ -120,7 +120,7 @@ public class AndCaseRuleTest {
         ArrayList<Board> cases = RULE.getCases(board, cell);
 
         // Make sure that the rule checks out
-        Assert.assertNotNull(RULE.checkRule(transition));
+        Assert.assertNull(RULE.checkRule(transition));
 
         // There should only be 1 branch
         Assert.assertEquals(1, cases.size());

--- a/src/test/java/puzzles/shorttruthtable/rules/OrCaseRuleTest.java
+++ b/src/test/java/puzzles/shorttruthtable/rules/OrCaseRuleTest.java
@@ -43,7 +43,7 @@ public class OrCaseRuleTest {
         ArrayList<Board> cases = RULE.getCases(board, cell);
 
         // Make sure that the rule checks out
-        Assert.assertNotNull(RULE.checkRule(transition));
+        Assert.assertNull(RULE.checkRule(transition));
 
         // Make sure there are two branches
         Assert.assertEquals(2, cases.size());
@@ -121,7 +121,7 @@ public class OrCaseRuleTest {
         ArrayList<Board> cases = RULE.getCases(board, cell);
 
         // Make sure that the rule checks out
-        Assert.assertNotNull(RULE.checkRule(transition));
+        Assert.assertNull(RULE.checkRule(transition));
 
         // There should only be 1 branch
         Assert.assertEquals(1, cases.size());


### PR DESCRIPTION
## Description
Fixes a bug where STT tests were using assertNotNull to validate if the rule works. Instead, it should have been using assertNull. This will cause some tests to fail, which is expected, as currently, case rules don't seem to be working properly.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<!-- If your pull request is not related to a particular issue, delete the statement below. -->
Closes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
