### PR TITLE
Make clicking tiles cycle between numbers, bomb, and empty tiles.

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
     <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default copy" />
   </state>
 </component>

--- a/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperCellFactory.java
+++ b/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperCellFactory.java
@@ -51,9 +51,11 @@ public class MinesweeperCellFactory extends ElementFactory {
             final MinesweeperCell cell = new MinesweeperCell(MinesweeperTileData.fromData(value), new Point(x, y));
             cell.setIndex(y * height + x);
             return cell;
-        } catch (NumberFormatException e) {
+        }
+        catch (NumberFormatException e) {
             throw new InvalidFileFormatException("Minesweeper Factory: unknown value where integer expected");
-        } catch (NullPointerException e) {
+        }
+        catch (NullPointerException e) {
             throw new InvalidFileFormatException("Minesweeper Factory: could not find attribute(s)");
         }
     }

--- a/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperController.java
+++ b/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperController.java
@@ -15,16 +15,10 @@ public class MinesweeperController extends ElementController {
         final int numberData = current.data();
         switch (event.getButton()) {
             case MouseEvent.BUTTON1:
-                if (numberData >= 8) {
-                    return MinesweeperTileData.empty();
-                }
-                return MinesweeperTileData.flag(numberData + 1);
+                return MinesweeperTileData.fromData(numberData + 1);
             case MouseEvent.BUTTON2:
             case MouseEvent.BUTTON3:
-                if (numberData <= 1) {
-                    return MinesweeperTileData.empty();
-                }
-                return MinesweeperTileData.flag(numberData - 1);
+                return MinesweeperTileData.fromData(numberData - 1);
         }
         return MinesweeperTileData.empty();
     }

--- a/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperElementView.java
+++ b/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperElementView.java
@@ -35,17 +35,26 @@ public class MinesweeperElementView extends GridElementView {
             graphics2D.setColor(FONT_COLOR);
             graphics2D.setFont(FONT);
             final FontMetrics metrics = graphics2D.getFontMetrics(FONT);
-            final String value = String.valueOf(puzzleElement.getData());
+            final String value = String.valueOf(((MinesweeperCell) puzzleElement).getData().data());
             final int xText = location.x + (size.width - metrics.stringWidth(value)) / 2;
             final int yText = location.y + ((size.height - metrics.getHeight()) / 2) + metrics.getAscent();
-            graphics2D.drawString(String.valueOf(puzzleElement.getData()), xText, yText);
-        } else {
-            // temp
+            graphics2D.drawString(value, xText, yText);
+            return;
+        }
+        if (type == MinesweeperTileType.UNSET) {
             graphics2D.setStroke(new BasicStroke(1));
-            graphics2D.setColor(Color.LIGHT_GRAY);
-            graphics2D.fillRect(location.x, location.y, size.width, size.height);
             graphics2D.setColor(Color.BLACK);
             graphics2D.drawRect(location.x, location.y, size.width, size.height);
+            graphics2D.setColor(Color.DARK_GRAY);
+            graphics2D.fillRect(location.x, location.y, size.width, size.height);
+            return;
+        }
+        if (type == MinesweeperTileType.EMPTY) {
+            graphics2D.setStroke(new BasicStroke(1));
+            graphics2D.setColor(Color.BLACK);
+            graphics2D.drawRect(location.x, location.y, size.width, size.height);
+            graphics2D.setColor(Color.GRAY);
+            graphics2D.fillRect(location.x, location.y, size.width, size.height);
         }
     }
 }

--- a/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperImporter.java
+++ b/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperImporter.java
@@ -79,7 +79,8 @@ public class MinesweeperImporter extends PuzzleImporter {
                 }
             }
             puzzle.setCurrentBoard(minesweeperBoard);
-        } catch (NumberFormatException e) {
+        }
+        catch (NumberFormatException e) {
             throw new InvalidFileFormatException("Minesweeper Importer: unknown value where integer expected");
         }
     }
@@ -89,7 +90,8 @@ public class MinesweeperImporter extends PuzzleImporter {
         if (!boardElement.getAttribute("size").isEmpty()) {
             final int size = Integer.parseInt(boardElement.getAttribute("size"));
             minesweeperBoard = new MinesweeperBoard(size);
-        } else {
+        }
+        else {
             if (!boardElement.getAttribute("width").isEmpty() && !boardElement.getAttribute("height").isEmpty()) {
                 final int width = Integer.parseInt(boardElement.getAttribute("width"));
                 final int height = Integer.parseInt(boardElement.getAttribute("height"));

--- a/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperTileData.java
+++ b/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperTileData.java
@@ -24,7 +24,12 @@ public final class MinesweeperTileData {
             case UNSET_DATA: return unset();
             case BOMB_DATA: return bomb();
             case EMPTY_DATA: return empty();
-            default: return flag(data);
+            default: {
+                if (data <= -2 || data > 8) {
+                    return unset();
+                }
+                return flag(data);
+            }
         }
     }
 

--- a/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperTileData.java
+++ b/src/main/java/edu/rpi/legup/puzzle/minesweeper/MinesweeperTileData.java
@@ -21,9 +21,12 @@ public final class MinesweeperTileData {
 
     public static @NotNull MinesweeperTileData fromData(int data) {
         switch (data) {
-            case UNSET_DATA: return unset();
-            case BOMB_DATA: return bomb();
-            case EMPTY_DATA: return empty();
+            case UNSET_DATA:
+                return unset();
+            case BOMB_DATA:
+                return bomb();
+            case EMPTY_DATA:
+                return empty();
             default: {
                 if (data <= -2 || data > 8) {
                     return unset();
@@ -33,7 +36,10 @@ public final class MinesweeperTileData {
         }
     }
 
-    public static @NotNull MinesweeperTileData unset() { return UNSET; };
+    public static @NotNull MinesweeperTileData unset() {
+        return UNSET;
+    }
+    
     public static @NotNull MinesweeperTileData bomb() {
         return BOMB;
     }

--- a/src/main/java/edu/rpi/legup/puzzle/minesweeper/rules/LessBombsThanFlagContradictionRule.java
+++ b/src/main/java/edu/rpi/legup/puzzle/minesweeper/rules/LessBombsThanFlagContradictionRule.java
@@ -10,12 +10,13 @@ import edu.rpi.legup.puzzle.nurikabe.NurikabeUtilities;
 import edu.rpi.legup.utility.DisjointSets;
 
 import java.util.Set;
-public class LessBombsThanFlagContradictionRule extends ContradictionRule{
+
+public class LessBombsThanFlagContradictionRule extends ContradictionRule {
     private final String NO_CONTRADICTION_MESSAGE = "Does not contain a contradiction at this index";
     private final String INVALID_USE_MESSAGE = "Contradiction must be a region";
 
     public LessBombsThanFlagContradictionRule() {
-        super("MINE-CONT-0000","Less Bombs Than Flag",
+        super("MINE-CONT-0000", "Less Bombs Than Flag",
                 "There can not be less then the number of Bombs around a flag then the specified number\n",
                 "edu/rpi/legup/images/nurikabe/contradictions/NoNumber.png");
     }
@@ -27,6 +28,5 @@ public class LessBombsThanFlagContradictionRule extends ContradictionRule{
     }
 
 
-    }
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
When clicking on tiles, they now cycle from 1-8 for flags, and also cycle between bomb and empty tiles.

<!-- If your pull request is not related to a particular issue, delete the statement below. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improvement to an already existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
